### PR TITLE
Option to show missing amiibos in amiibo browser (they cant be selected).

### DIFF
--- a/app/src/main/java/com/hiddenramblings/tagmo/BrowserAmiibosAdapter.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/BrowserAmiibosAdapter.java
@@ -2,6 +2,7 @@ package com.hiddenramblings.tagmo;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -32,6 +33,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 
 class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.AmiiboVewHolder> implements
     Filterable,
@@ -63,7 +65,8 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
             !Util.equals(newBrowserSettings.getGameSeriesFilter(), oldBrowserSettings.getGameSeriesFilter()) ||
             !Util.equals(newBrowserSettings.getCharacterFilter(), oldBrowserSettings.getCharacterFilter()) ||
             !Util.equals(newBrowserSettings.getAmiiboSeriesFilter(), oldBrowserSettings.getAmiiboSeriesFilter()) ||
-            !Util.equals(newBrowserSettings.getAmiiboTypeFilter(), oldBrowserSettings.getAmiiboTypeFilter());
+            !Util.equals(newBrowserSettings.getAmiiboTypeFilter(), oldBrowserSettings.getAmiiboTypeFilter()) ||
+            !Util.equals(newBrowserSettings.isMissingAmiibosShown(), oldBrowserSettings.isMissingAmiibosShown());
 
         if (firstRun || !Util.equals(newBrowserSettings.getAmiiboFiles(), oldBrowserSettings.getAmiiboFiles())) {
             this.data.clear();
@@ -124,19 +127,19 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
     class AmiiboComparator implements Comparator<AmiiboFile> {
         @Override
         public int compare(AmiiboFile amiiboFile1, AmiiboFile amiiboFile2) {
+            int value = 0;
+            int sort = settings.getSort();
+
             File filePath1 = amiiboFile1.getFilePath();
             File filePath2 = amiiboFile2.getFilePath();
+            if (sort == BrowserActivity.SORT_FILE_PATH && !(filePath1 == null && filePath2 == null))
+                value = compareFilePath(filePath1, filePath2);
 
-            int sort = settings.getSort();
-            if (sort == BrowserActivity.SORT_FILE_PATH)
-                return filePath1.compareTo(filePath2);
-
-            int value = 0;
             long amiiboId1 = amiiboFile1.getId();
             long amiiboId2 = amiiboFile2.getId();
             if (sort == BrowserActivity.SORT_ID) {
                 value = compareAmiiboId(amiiboId1, amiiboId2);
-            } else {
+            } else if (value == 0) {
                 AmiiboManager amiiboManager = settings.getAmiiboManager();
                 if (amiiboManager != null) {
                     Amiibo amiibo1 = amiiboManager.amiibos.get(amiiboId1);
@@ -164,9 +167,19 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
             }
 
             if (value == 0)
-                value = filePath1.compareTo(filePath2);
+                value = compareFilePath(filePath1, filePath2);
 
             return value;
+        }
+
+        int compareFilePath(File filePath1, File filePath2) {
+            if (filePath1 == null) {
+                return 1;
+            } else if (filePath2 == null) {
+                return -1;
+            } else {
+                return filePath1.compareTo(filePath2);
+            }
         }
 
         int compareAmiiboId(long amiiboId1, long amiiboId2) {
@@ -250,17 +263,30 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
             String query = constraint != null ? constraint.toString() : "";
             settings.setQuery(query);
 
-            FilterResults filterResults = new FilterResults();
-            ArrayList<AmiiboFile> tempList = new ArrayList<>();
-            String queryText = query.trim().toLowerCase();
             ArrayList<AmiiboFile> data = new ArrayList<>();
             if (settings.getAmiiboFiles() != null) {
                 data.addAll(settings.getAmiiboFiles());
             }
+
+            AmiiboManager amiiboManager = settings.getAmiiboManager();
+            if (amiiboManager != null && settings.isMissingAmiibosShown()) {
+                HashSet<Long> amiiboIds = new HashSet<>();
+                for (AmiiboFile amiiboFile : data) {
+                    amiiboIds.add(amiiboFile.getId());
+                }
+                for (Amiibo amiibo : amiiboManager.amiibos.values()) {
+                    if (!amiiboIds.contains(amiibo.id)) {
+                        data.add(new AmiiboFile(null, amiibo.id));
+                    }
+                }
+            }
+
+            FilterResults filterResults = new FilterResults();
+            ArrayList<AmiiboFile> tempList = new ArrayList<>();
+            String queryText = query.trim().toLowerCase();
             for (AmiiboFile amiiboFile : data) {
                 boolean add;
 
-                AmiiboManager amiiboManager = settings.getAmiiboManager();
                 if (amiiboManager != null) {
                     Amiibo amiibo = amiiboManager.amiibos.get(amiiboFile.getId());
                     if (amiibo == null)
@@ -269,7 +295,7 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
                 } else {
                     add = queryText.isEmpty();
                 }
-                if (!add)
+                if (!add && amiiboFile.getFilePath() != null)
                     add = pathContainsQuery(amiiboFile.getFilePath().getAbsolutePath(), queryText);
                 if (add)
                     tempList.add(amiiboFile);
@@ -337,6 +363,7 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         private final BrowserSettings settings;
         private final OnAmiiboClickListener listener;
 
+        public final TextView txtError;
         public final TextView txtName;
         public final TextView txtTagId;
         public final TextView txtAmiiboSeries;
@@ -380,6 +407,7 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
                 }
             });
 
+            this.txtError = itemView.findViewById(R.id.txtError);
             this.txtName = itemView.findViewById(R.id.txtName);
             this.txtTagId = itemView.findViewById(R.id.txtTagId);
             this.txtAmiiboSeries = itemView.findViewById(R.id.txtAmiiboSeries);
@@ -439,16 +467,25 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
             String query = settings.getQuery().toLowerCase();
 
             if (tagInfo == null) {
-                setAmiiboInfoText(this.txtName, boldMatchingText(amiiboName, query), false);
+                txtError.setVisibility(View.GONE);
             } else {
-                setAmiiboInfoText(this.txtName, tagInfo, false);
+                setAmiiboInfoText(this.txtError, tagInfo, false);
             }
+            setAmiiboInfoText(this.txtName, amiiboName, false);
             setAmiiboInfoText(this.txtTagId, boldStartText(amiiboHexId, query), tagInfo != null);
             setAmiiboInfoText(this.txtAmiiboSeries, boldMatchingText(amiiboSeries, query), tagInfo != null);
             setAmiiboInfoText(this.txtAmiiboType, boldMatchingText(amiiboType, query), tagInfo != null);
             setAmiiboInfoText(this.txtGameSeries, boldMatchingText(gameSeries, query), tagInfo != null);
             //setAmiiboInfoText(this.txtCharacter, boldMatchingText(character, query), tagInfo != null);
-            this.txtPath.setText(boldMatchingText(Util.friendlyPath(item.getFilePath()), query));
+            if (item.getFilePath() != null) {
+                this.itemView.setEnabled(true);
+                this.txtPath.setText(boldMatchingText(Util.friendlyPath(item.getFilePath()), query));
+                this.txtPath.setTextColor(this.txtPath.getResources().getColor(R.color.tag_text));
+            } else {
+                this.itemView.setEnabled(false);
+                this.txtPath.setText("No files for this Amiibo found");
+                this.txtPath.setTextColor(Color.RED);
+            }
             this.txtPath.setVisibility(View.VISIBLE);
 
             if (this.imageAmiibo != null) {

--- a/app/src/main/java/com/hiddenramblings/tagmo/BrowserSettings.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/BrowserSettings.java
@@ -29,7 +29,8 @@ public class BrowserSettings {
     protected String filterAmiiboType;
     protected int browserAmiiboView;
     protected String imageNetworkSettings;
-    protected boolean recursiveFiles;
+    protected boolean scanSubfoldersEnabled;
+    protected boolean missingAmiibosShown;
 
     public BrowserSettings() {
         oldBrowserSettings = new BrowserSettings(false);
@@ -40,7 +41,7 @@ public class BrowserSettings {
         ArrayList<AmiiboFile> amiiboFiles, ArrayList<File> folders, File browserFolder,
         String query, int sort, String filterGameSeries, String filterCharacter,
         String filterAmiiboSeries, String filterAmiiboType, int browserAmiiboView,
-        String imageNetworkSettings, boolean recursiveFiles
+        String imageNetworkSettings, boolean scanSubfoldersEnabled, boolean missingAmiibosShown
     ) {
         super();
 
@@ -55,7 +56,8 @@ public class BrowserSettings {
         this.filterAmiiboType = filterAmiiboType;
         this.browserAmiiboView = browserAmiiboView;
         this.imageNetworkSettings = imageNetworkSettings;
-        this.recursiveFiles = recursiveFiles;
+        this.scanSubfoldersEnabled = scanSubfoldersEnabled;
+        this.missingAmiibosShown = missingAmiibosShown;
     }
 
     private BrowserSettings(boolean duplicate) {
@@ -162,12 +164,20 @@ public class BrowserSettings {
         this.imageNetworkSettings = imageNetworkSettings;
     }
 
-    public boolean isRecursiveFiles() {
-        return recursiveFiles;
+    public boolean isScanSubfoldersEnabled() {
+        return scanSubfoldersEnabled;
     }
 
-    public void setRecursiveFiles(boolean recursiveFiles) {
-        this.recursiveFiles = recursiveFiles;
+    public void setScanSubfoldersEnabled(boolean scanSubfoldersEnabled) {
+        this.scanSubfoldersEnabled = scanSubfoldersEnabled;
+    }
+
+    public boolean isMissingAmiibosShown() {
+        return missingAmiibosShown;
+    }
+
+    public void setMissingAmiibosShown(boolean missingAmiibosShown) {
+        this.missingAmiibosShown = missingAmiibosShown;
     }
 
     public void notifyChanges() {
@@ -183,6 +193,10 @@ public class BrowserSettings {
 
     public void removeChangeListener(BrowserSettingsListener listener) {
         this.listeners.remove(listener);
+    }
+
+    public void removeAllChangeListeners() {
+        this.listeners.clear();
     }
 
     interface BrowserSettingsListener {
@@ -203,7 +217,8 @@ public class BrowserSettings {
         copy.setAmiiboView(this.getAmiiboView());
         copy.setBrowserRootFolder(this.getBrowserRootFolder());
         copy.setImageNetworkSettings(this.getImageNetworkSettings());
-        copy.setRecursiveFiles(this.isRecursiveFiles());
+        copy.setScanSubfoldersEnabled(this.isScanSubfoldersEnabled());
+        copy.setMissingAmiibosShown(this.isMissingAmiibosShown());
 
         return copy;
     }

--- a/app/src/main/java/com/hiddenramblings/tagmo/MainActivity.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/MainActivity.java
@@ -83,6 +83,7 @@ public class MainActivity extends AppCompatActivity {
     public static final int VIEW_TYPE_COMPACT = 1;
     public static final int VIEW_TYPE_LARGE = 2;
 
+    TextView txtError;
     TextView txtTagId;
     TextView txtName;
     TextView txtGameSeries;
@@ -440,6 +441,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         amiiboInfoView.addView(amiiboView);
+        txtError = amiiboView.findViewById(R.id.txtError);
         txtTagId = amiiboView.findViewById(R.id.txtTagId);
         txtName = amiiboView.findViewById(R.id.txtName);
         txtGameSeries = amiiboView.findViewById(R.id.txtGameSeries);
@@ -549,10 +551,11 @@ public class MainActivity extends AppCompatActivity {
         }
 
         if (tagInfo == null) {
-            setAmiiboInfoText(txtName, amiiboName, false);
+            txtError.setVisibility(View.GONE);
         } else {
-            setAmiiboInfoText(txtName, tagInfo, false);
+            setAmiiboInfoText(txtError, tagInfo, false);
         }
+        setAmiiboInfoText(txtName, amiiboName, tagInfo != null);
         setAmiiboInfoText(txtTagId, amiiboHexId, tagInfo != null);
         setAmiiboInfoText(txtAmiiboSeries, amiiboSeries, tagInfo != null);
         setAmiiboInfoText(txtAmiiboType, amiiboType, tagInfo != null);

--- a/app/src/main/java/com/hiddenramblings/tagmo/Preferences.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/Preferences.java
@@ -41,5 +41,8 @@ public interface Preferences {
     String browserRootFolder();
 
     @DefaultBoolean(true)
-    boolean recursiveFiles();
+    boolean scanSubfoldersEnabled();
+
+    @DefaultBoolean(false)
+    boolean missingAmiibosShown();
 }

--- a/app/src/main/res/drawable-v21/card_foreground.xml
+++ b/app/src/main/res/drawable-v21/card_foreground.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="#20000000"
-    android:drawable="@drawable/card_foreground_selector"/>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape>
+            <solid android:color="#18000000" />
+        </shape>
+    </item>
+    <item>
+        <ripple
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:color="#20000000"
+            android:drawable="@drawable/card_foreground_selector"/>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/card_foreground.xml
+++ b/app/src/main/res/drawable/card_foreground.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<inset
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:drawable="@drawable/card_foreground_selector"
-    android:insetBottom="4dp"
-    android:insetLeft="2dp"
-    android:insetRight="2dp"
-    android:insetTop="4dp"/>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape>
+            <solid android:color="#18000000" />
+        </shape>
+    </item>
+    <item>
+        <inset
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:drawable="@drawable/card_foreground_selector"
+            android:insetBottom="4dp"
+            android:insetLeft="2dp"
+            android:insetRight="2dp"
+            android:insetTop="4dp"/>
+    </item>
+</selector>

--- a/app/src/main/res/layout/amiibo_compact_card.xml
+++ b/app/src/main/res/layout/amiibo_compact_card.xml
@@ -27,6 +27,17 @@
             android:foreground="@drawable/card_foreground"
             android:visibility="gone"/>
 
+        <TextView
+            android:id="@+id/txtError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:padding="8dp"
+            android:text="ERROR"
+            android:textAlignment="center"
+            android:textColor="@color/tag_text"
+            android:textSize="16dp"/>
+
         <RelativeLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -111,6 +122,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/group2"
                 android:text="PATH"
+                android:textColor="@color/tag_text"
                 android:textSize="10dp"
                 android:visibility="gone"/>
         </RelativeLayout>

--- a/app/src/main/res/layout/amiibo_large_card.xml
+++ b/app/src/main/res/layout/amiibo_large_card.xml
@@ -25,6 +25,17 @@
             android:foreground="@drawable/card_foreground"
             android:visibility="gone"/>
 
+        <TextView
+            android:id="@+id/txtError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:textAlignment="center"
+            android:text="ERROR"
+            android:textColor="@color/tag_text"
+            android:padding="8dp"
+            android:textSize="16dp"/>
+
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -108,6 +119,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/group2"
                 android:text="PATH"
+                android:textColor="@color/tag_text"
                 android:textSize="10dp"
                 android:visibility="gone"/>
         </RelativeLayout>

--- a/app/src/main/res/layout/amiibo_simple_card.xml
+++ b/app/src/main/res/layout/amiibo_simple_card.xml
@@ -19,6 +19,17 @@
         android:padding="8dp">
 
         <TextView
+            android:id="@+id/txtError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:padding="8dp"
+            android:text="ERROR"
+            android:textAlignment="center"
+            android:textColor="@color/tag_text"
+            android:textSize="16dp"/>
+
+        <TextView
             android:id="@+id/txtName"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -96,6 +107,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/group2"
             android:text="PATH"
+            android:textColor="@color/tag_text"
             android:textSize="10dp"
             android:visibility="gone"/>
     </RelativeLayout>

--- a/app/src/main/res/menu/browser_menu.xml
+++ b/app/src/main/res/menu/browser_menu.xml
@@ -102,10 +102,15 @@
         </menu>
     </item>
     <item
-        android:id="@+id/recursive_files"
-        android:title="Find Files Recursively"
-        app:showAsAction="ifRoom"
-        android:checkable="true"/>
+        android:id="@+id/scan_subfolders"
+        android:checkable="true"
+        android:title="Scan Subfolders"
+        app:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/show_missing"
+        android:checkable="true"
+        android:title="Show Missing Amiibos"
+        app:showAsAction="ifRoom"/>
     <item
         android:id="@+id/refresh"
         android:icon="@drawable/ic_refresh_white_24dp"


### PR DESCRIPTION
Option to show missing amiibos in amiibo browser (they cant be selected).

Only enabled when recursive files mode is enabled.