### PR TITLE
Compatibility layer for Xperia phones / upgrade to gradle 3.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.hiddenramblings.tagmo"
@@ -31,7 +30,7 @@ android {
         fat {
             dimension "abi"
             ndk {
-                abiFilters "x86", "armeabi-v7a", "armeabi"
+                abiFilters "x86", "armeabi-v7a", "arm64-v8a"
                 versionCode = 0
             }
         }
@@ -42,7 +41,7 @@ android {
         abi {
             enable true
             reset()
-            include 'x86', 'armeabi-v7a'
+            include 'x86', 'armeabi-v7a', "arm64-v8a"
             universalApk true
         }
     }

--- a/app/src/main/java/com/hiddenramblings/tagmo/NTAG215.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/NTAG215.java
@@ -1,0 +1,131 @@
+package com.hiddenramblings.tagmo;
+
+import android.nfc.Tag;
+import android.nfc.tech.MifareUltralight;
+import android.nfc.tech.NfcA;
+
+import java.io.IOException;
+
+public class NTAG215 {
+    private MifareUltralight m_mifare;
+    private NfcA m_nfcA;
+    public static final int PAGE_SIZE = 4;
+
+    private static final int NXP_MANUFACTURER_ID = 0x04;
+    private static final int MAX_PAGE_COUNT = 256;
+
+    public static final int CMD_GET_VERSION = 0x60;
+    public static final int CMD_READ = 0x30;
+    public static final int CMD_FAST_READ = 0x3A;
+    public static final int CMD_WRITE = 0xA2;
+    public static final int CMD_COMP_WRITE = 0xA0;
+    public static final int CMD_READ_CNT = 0x39;
+    public static final int CMD_PWD_AUTH = 0x1B;
+    public static final int CMD_READ_SIG = 0x3C;
+
+
+    public NTAG215(MifareUltralight mifare) {
+        m_nfcA = null;
+        m_mifare = mifare;
+    }
+    public NTAG215(NfcA nfcA) {
+        m_nfcA = nfcA;
+        m_mifare = null;
+    }
+
+    public static NTAG215 get(Tag tag) {
+        MifareUltralight mifare = MifareUltralight.get(tag);
+        if (mifare!=null)
+            return new NTAG215(mifare);
+        NfcA nfcA = NfcA.get(tag);
+        if ( nfcA!=null) {
+            if (nfcA.getSak() == 0x00 && tag.getId()[0] == NXP_MANUFACTURER_ID)
+                return new NTAG215(nfcA);
+        }
+
+        return null;
+    }
+
+    public byte[] readPages(int pageOffset) throws IOException {
+        if ( m_mifare!=null)
+            return m_mifare.readPages(pageOffset);
+        else if ( m_nfcA!=null) {
+            validatePageIndex(pageOffset);
+            //checkConnected();
+
+            byte[] cmd = {CMD_READ, (byte) pageOffset};
+            return m_nfcA.transceive(cmd);
+        }
+        return null;
+    }
+
+    public void writePage(int pageOffset, byte[] data) throws IOException {
+        if (m_mifare!=null) {
+            m_mifare.writePage(pageOffset,data);
+            return;
+        }
+        else if ( m_nfcA!=null ) {
+            validatePageIndex(pageOffset);
+            //m_nfcA.checkConnected();
+
+            byte[] cmd = new byte[data.length + 2];
+            cmd[0] = (byte) CMD_WRITE;
+            cmd[1] = (byte) pageOffset;
+            System.arraycopy(data, 0, cmd, 2, data.length);
+
+            m_nfcA.transceive(cmd);
+            return ;
+        }
+
+        return;
+    }
+
+    public byte[] transceive(byte[] data) throws IOException {
+        if ( m_mifare!=null) {
+            return m_mifare.transceive(data);
+        }
+        else if ( m_nfcA!=null) {
+            return m_nfcA.transceive(data);
+        }
+        return null;
+    }
+
+    private static void validatePageIndex(int pageIndex) {
+        // Do not be too strict on upper bounds checking, since some cards
+        // may have more addressable memory than they report.
+        // Note that issuing a command to an out-of-bounds block is safe - the
+        // tag will wrap the read to an addressable area. This validation is a
+        // helper to guard against obvious programming mistakes.
+        if (pageIndex < 0 || pageIndex >= MAX_PAGE_COUNT) {
+            throw new IndexOutOfBoundsException("page out of bounds: " + pageIndex);
+        }
+    }
+
+    public void connect() throws IOException {
+        if ( m_mifare!=null) {
+            m_mifare.connect();
+        }
+        else if ( m_nfcA!=null) {
+            m_nfcA.connect();
+        }
+    }
+
+    public void close() throws IOException {
+        if ( m_mifare!=null) {
+            m_mifare.close();
+        }
+        else if ( m_nfcA!=null) {
+            m_nfcA.close();
+        }
+    }
+
+    public Tag getTag() {
+        if ( m_mifare!=null) {
+            return m_mifare.getTag();
+        }
+        else if ( m_nfcA!=null) {
+            return m_nfcA.getTag();
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/NfcActivity.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/NfcActivity.java
@@ -9,7 +9,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.nfc.NfcAdapter;
 import android.nfc.Tag;
-import android.nfc.tech.MifareUltralight;
 import android.os.Build;
 import android.provider.Settings;
 import android.support.v7.app.AlertDialog;
@@ -151,7 +150,7 @@ public class NfcActivity extends AppCompatActivity {
         try {
             Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
             Log.d(TAG, tag.toString());
-            MifareUltralight mifare = MifareUltralight.get(tag);
+            NTAG215 mifare = NTAG215.get(tag);
             if (mifare == null)
                 throw new Exception("Error getting tag data. Possibly not a NTAG215");
             mifare.connect();
@@ -212,6 +211,7 @@ public class NfcActivity extends AppCompatActivity {
                 error = error + "\n" + e.getCause().toString();
             showError(error);
         }
+
     }
 
     @UiThread

--- a/app/src/main/java/com/hiddenramblings/tagmo/TagWriter.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/TagWriter.java
@@ -1,6 +1,5 @@
 package com.hiddenramblings.tagmo;
 
-import android.nfc.tech.MifareUltralight;
 import android.util.Log;
 
 import com.hiddenramblings.tagmo.ptag.PTagKeyManager;
@@ -19,7 +18,7 @@ public class TagWriter {
     private static final byte[] COMP_WRITE_CMD = Util.hexStringToByteArray("a000");
     private static final byte[] SIG_CMD = Util.hexStringToByteArray("3c00");
 
-    public static void writeToTagRaw(MifareUltralight mifare, byte[] tagData, boolean validateNtag) throws Exception {
+    public static void writeToTagRaw(NTAG215 mifare, byte[] tagData, boolean validateNtag) throws Exception {
         validate(mifare, tagData, validateNtag);
 
         validateBlankTag(mifare);
@@ -45,7 +44,7 @@ public class TagWriter {
         }
     }
 
-    private static void validateBlankTag(MifareUltralight mifare) throws Exception {
+    private static void validateBlankTag(NTAG215 mifare) throws Exception {
         byte[] lockPage = mifare.readPages(0x02);
         Log.d(TAG, Util.bytesToHex(lockPage));
         if (lockPage[2] == (byte) 0x0F && lockPage[3] == (byte) 0xE0) {
@@ -55,7 +54,7 @@ public class TagWriter {
         Log.d(TAG, "not locked");
     }
 
-    public static void writeToTagAuto(MifareUltralight mifare, byte[] tagData, KeyManager keyManager, boolean validateNtag, boolean supportPowerTag) throws Exception {
+    public static void writeToTagAuto(NTAG215 mifare, byte[] tagData, KeyManager keyManager, boolean validateNtag, boolean supportPowerTag) throws Exception {
         byte[] idPages = mifare.readPages(0);
         if (idPages == null || idPages.length != TagUtil.PAGE_SIZE * 4)
             throw new Exception("Read failed! Unexpected read size.");
@@ -137,7 +136,7 @@ public class TagWriter {
         }
     }
 
-    public static void restoreTag(MifareUltralight mifare, byte[] tagData, boolean ignoreUid, KeyManager keyManager, boolean validateNtag) throws Exception {
+    public static void restoreTag(NTAG215 mifare, byte[] tagData, boolean ignoreUid, KeyManager keyManager, boolean validateNtag) throws Exception {
         if (!ignoreUid)
             validate(mifare, tagData, validateNtag);
         else {
@@ -160,7 +159,7 @@ public class TagWriter {
         writePages(mifare, 32, 129, pages);
     }
 
-    static void validate(MifareUltralight mifare, byte[] tagData, boolean validateNtag) throws Exception {
+    static void validate(NTAG215 mifare, byte[] tagData, boolean validateNtag) throws Exception {
         if (tagData == null)
             throw new Exception("Cannot validate: no source data loaded to compare.");
 
@@ -197,7 +196,7 @@ public class TagWriter {
 
     public static final int BULK_READ_PAGE_COUNT = 4;
 
-    public static byte[] readFromTag(MifareUltralight tag) throws Exception {
+    public static byte[] readFromTag(NTAG215 tag) throws Exception {
         byte[] tagData = new byte[TagUtil.TAG_FILE_SIZE];
         int pageCount = TagUtil.TAG_FILE_SIZE / TagUtil.PAGE_SIZE;
 
@@ -216,14 +215,14 @@ public class TagWriter {
         return tagData;
     }
 
-    static void writePages(MifareUltralight tag, int pagestart, int pageend, byte[][] data) throws IOException {
+    static void writePages(NTAG215 tag, int pagestart, int pageend, byte[][] data) throws IOException {
         for (int i = pagestart; i <= pageend; i++) {
             tag.writePage(i, data[i]);
             Log.d(TAG, "Wrote to page " + i);
         }
     }
 
-    static void writePassword(MifareUltralight tag) throws IOException {
+    static void writePassword(NTAG215 tag) throws IOException {
         byte[] pages0_1 = tag.readPages(0);
 
         if (pages0_1 == null || pages0_1.length != TagUtil.PAGE_SIZE * 4)
@@ -242,7 +241,7 @@ public class TagWriter {
         Log.d(TAG, "pwd done");
     }
 
-    static void writeLockInfo(MifareUltralight tag) throws IOException {
+    static void writeLockInfo(NTAG215 tag) throws IOException {
         byte[] pages = tag.readPages(0);
 
         if (pages == null || pages.length != TagUtil.PAGE_SIZE * 4)
@@ -254,7 +253,7 @@ public class TagWriter {
         tag.writePage(132, new byte[]{(byte) 0x5F, (byte) 0x00, (byte) 0x00, (byte) 0x00}); //config
     }
 
-    static void doAuth(MifareUltralight tag) throws Exception {
+    static void doAuth(NTAG215 tag) throws Exception {
         byte[] pages0_1 = tag.readPages(0);
 
         if (pages0_1 == null || pages0_1.length != TagUtil.PAGE_SIZE * 4)

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         //}
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/ndk/jni/Application.mk
+++ b/ndk/jni/Application.mk
@@ -1,1 +1,1 @@
-APP_ABI := armeabi armeabi-v7a x86
+APP_ABI := armeabi-v7a x86 arm64-v8a


### PR DESCRIPTION
Upgraded to gradle 3.2.1 to fix errors on newer Android Studio versions.
Added compatibilty layer for phones that do not support MifareUltralight, but do support NfcA.