### PR TITLE
Fixed crash when loading amiibo file browser

### DIFF
--- a/app/src/main/java/com/hiddenramblings/tagmo/BrowserAmiibosAdapter.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/BrowserAmiibosAdapter.java
@@ -141,7 +141,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
                 if (amiiboManager != null) {
                     Amiibo amiibo1 = amiiboManager.amiibos.get(amiiboId1);
                     Amiibo amiibo2 = amiiboManager.amiibos.get(amiiboId2);
-                    if (amiibo1 == null)
+                    if (amiibo1 == null && amiibo2 == null)
+                        value = 0;
+                    else if (amiibo1 == null)
                         value = 1;
                     else if (amiibo2 == null)
                         value = -1;
@@ -156,7 +158,7 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
                     } else if (sort == BrowserActivity.SORT_CHARACTER) {
                         value = compareCharacter(amiibo1, amiibo2);
                     }
-                    if (value == 0)
+                    if (value == 0 && amiibo1 != null)
                         value = amiibo1.compareTo(amiibo2);
                 }
                 if (value == 0)
@@ -178,6 +180,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareAmiiboName(Amiibo amiibo1, Amiibo amiibo2) {
             String name1 = amiibo1.name;
             String name2 = amiibo2.name;
+			if (name1 == null && name2 == null) {
+				return 0;
+			}
             if (name1 == null) {
                 return 1;
             } else if (name2 == null) {
@@ -189,6 +194,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareAmiiboSeries(Amiibo amiibo1, Amiibo amiibo2) {
             AmiiboSeries amiiboSeries1 = amiibo1.getAmiiboSeries();
             AmiiboSeries amiiboSeries2 = amiibo2.getAmiiboSeries();
+			if (amiiboSeries1 == null && amiiboSeries2 == null ) {
+				return 0;
+			}
             if (amiiboSeries1 == null) {
                 return 1;
             } else if (amiiboSeries2 == null) {
@@ -200,6 +208,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareAmiiboType(Amiibo amiibo1, Amiibo amiibo2) {
             AmiiboType amiiboType1 = amiibo1.getAmiiboType();
             AmiiboType amiiboType2 = amiibo2.getAmiiboType();
+			if (amiiboType1 == null && amiiboType2 == null ) {
+				return 0;
+			}
             if (amiiboType1 == null) {
                 return 1;
             } else if (amiiboType2 == null) {
@@ -211,6 +222,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareGameSeries(Amiibo amiibo1, Amiibo amiibo2) {
             GameSeries gameSeries1 = amiibo1.getGameSeries();
             GameSeries gameSeries2 = amiibo2.getGameSeries();
+			if (gameSeries1 == null && gameSeries2 == null) {
+				return 0;
+			}
             if (gameSeries1 == null) {
                 return 1;
             } else if (gameSeries2 == null) {
@@ -222,6 +236,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareCharacter(Amiibo amiibo1, Amiibo amiibo2) {
             Character character1 = amiibo1.getCharacter();
             Character character2 = amiibo2.getCharacter();
+			if (character1 == null && character2 == null) {
+				return 0;
+			}
             if (character1 == null) {
                 return 1;
             } else if (character2 == null) {

--- a/app/src/main/java/com/hiddenramblings/tagmo/BrowserAmiibosAdapter.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/BrowserAmiibosAdapter.java
@@ -180,9 +180,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareAmiiboName(Amiibo amiibo1, Amiibo amiibo2) {
             String name1 = amiibo1.name;
             String name2 = amiibo2.name;
-			if (name1 == null && name2 == null) {
-				return 0;
-			}
+            if (name1 == null && name2 == null) {
+                return 0;
+            }
             if (name1 == null) {
                 return 1;
             } else if (name2 == null) {
@@ -194,9 +194,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareAmiiboSeries(Amiibo amiibo1, Amiibo amiibo2) {
             AmiiboSeries amiiboSeries1 = amiibo1.getAmiiboSeries();
             AmiiboSeries amiiboSeries2 = amiibo2.getAmiiboSeries();
-			if (amiiboSeries1 == null && amiiboSeries2 == null ) {
-				return 0;
-			}
+            if (amiiboSeries1 == null && amiiboSeries2 == null ) {
+                return 0;
+            }
             if (amiiboSeries1 == null) {
                 return 1;
             } else if (amiiboSeries2 == null) {
@@ -208,9 +208,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareAmiiboType(Amiibo amiibo1, Amiibo amiibo2) {
             AmiiboType amiiboType1 = amiibo1.getAmiiboType();
             AmiiboType amiiboType2 = amiibo2.getAmiiboType();
-			if (amiiboType1 == null && amiiboType2 == null ) {
-				return 0;
-			}
+            if (amiiboType1 == null && amiiboType2 == null ) {
+                return 0;
+            }
             if (amiiboType1 == null) {
                 return 1;
             } else if (amiiboType2 == null) {
@@ -222,9 +222,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareGameSeries(Amiibo amiibo1, Amiibo amiibo2) {
             GameSeries gameSeries1 = amiibo1.getGameSeries();
             GameSeries gameSeries2 = amiibo2.getGameSeries();
-			if (gameSeries1 == null && gameSeries2 == null) {
-				return 0;
-			}
+            if (gameSeries1 == null && gameSeries2 == null) {
+                return 0;
+            }
             if (gameSeries1 == null) {
                 return 1;
             } else if (gameSeries2 == null) {
@@ -236,9 +236,9 @@ class BrowserAmiibosAdapter extends RecyclerView.Adapter<BrowserAmiibosAdapter.A
         int compareCharacter(Amiibo amiibo1, Amiibo amiibo2) {
             Character character1 = amiibo1.getCharacter();
             Character character2 = amiibo2.getCharacter();
-			if (character1 == null && character2 == null) {
-				return 0;
-			}
+            if (character1 == null && character2 == null) {
+                return 0;
+            }
             if (character1 == null) {
                 return 1;
             } else if (character2 == null) {


### PR DESCRIPTION
When loading amiibo file browser, it crashed with exception on some conditions.

the callstack looks like this:
    java.lang.IllegalArgumentException: Comparison method violates its general contract!
        at java.util.TimSort.mergeLo(TimSort.java:777)
        at java.util.TimSort.mergeAt(TimSort.java:514)
        at java.util.TimSort.mergeCollapse(TimSort.java:439)
        at java.util.TimSort.sort(TimSort.java:245)
        at java.util.Arrays.sort(Arrays.java:1492)
        at java.util.ArrayList.sort(ArrayList.java:1470)
        at java.util.Collections.sort(Collections.java:206)
        at com.hiddenramblings.tagmo.BrowserAmiibosAdapter$AmiiboFilter.publishResults(BrowserAmiibosAdapter.java:330)
        at android.widget.Filter$ResultsHandler.handleMessage(Filter.java:284)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:237)
        at android.app.ActivityThread.main(ActivityThread.java:7860)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1075)