### PR TITLE
Experimental restore of legacy device compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.hiddenramblings.tagmo"
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 26
         versionCode 5
         versionName "2.7.0"
@@ -63,4 +63,5 @@ dependencies {
     implementation "org.androidannotations:androidannotations-api:4.6.0"
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
+    implementation 'com.google.android.gms:play-services-safetynet:17.0.1'
 }


### PR DESCRIPTION
Per Android Studio, the minimum required API for all implemented libraries is 16. While 16 does not properly support current SSL standards, Google Play Services can override a known bug and restore SSL support to these devices.

This PR will revert the minimum API required to 16 and use Google Play Services to patch the SSL bug, but only on those devices that are old enough to require it. No Google Play Services requirement will be enforced for newer devices that have functional SSL support.

Resolves the sync issue in https://github.com/HiddenRamblings/TagMo/issues/246