### PR TITLE
Adopt to Zulu as the build openjdk distribution. 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'zulu'
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.
Zulu has builds for fixed versions (archived) prior to Sept 2021 and many non-LTS versions. Temurin mainly supports the LTS versions and (JDK 16).