### PR TITLE
add check updates setting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ android {
 
         def commit = 'git rev-parse --short HEAD'.execute().text.trim()
         buildConfigField "String", "COMMIT", "\""+commit+"\""
+        signingConfig signingConfigs.debug
         project.archivesBaseName = "TagMo-" + commit
     }
 

--- a/app/src/main/java/com/hiddenramblings/tagmo/BrowserActivity.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/BrowserActivity.java
@@ -235,30 +235,33 @@ public class BrowserActivity extends AppCompatActivity implements
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            checkForUpdate();
-        } else {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-            ProviderInstaller.installIfNeededAsync(this,
-                    new ProviderInstaller.ProviderInstallListener() {
-                @Override
-                public void onProviderInstalled() {
-                    checkForUpdate();
-                }
+        boolean updatesEnabled = prefs.settings_enable_updates().get();
+        if (updatesEnabled) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                checkForUpdate();
+            } else {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+                ProviderInstaller.installIfNeededAsync(this,
+                        new ProviderInstaller.ProviderInstallListener() {
+                            @Override
+                            public void onProviderInstalled() {
+                                checkForUpdate();
+                            }
 
-                @Override
-                public void onProviderInstallFailed(int errorCode, Intent recoveryIntent) {
-                    GoogleApiAvailability availability = GoogleApiAvailability.getInstance();
-                    if (availability.isUserResolvableError(errorCode)) {
-                        availability.showErrorDialogFragment(
-                                BrowserActivity.this, errorCode, 7000,
-                                dialog -> onProviderInstallerNotAvailable());
-                    } else {
-                        onProviderInstallerNotAvailable();
-                    }
-                }
-            });
+                            @Override
+                            public void onProviderInstallFailed(int errorCode, Intent recoveryIntent) {
+                                GoogleApiAvailability availability = GoogleApiAvailability.getInstance();
+                                if (availability.isUserResolvableError(errorCode)) {
+                                    availability.showErrorDialogFragment(
+                                            BrowserActivity.this, errorCode, 7000,
+                                            dialog -> onProviderInstallerNotAvailable());
+                                } else {
+                                    onProviderInstallerNotAvailable();
+                                }
+                            }
+                        });
+            }
         }
 
         Intent intent = getIntent();

--- a/app/src/main/java/com/hiddenramblings/tagmo/settings/Preferences.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/settings/Preferences.java
@@ -48,6 +48,9 @@ public interface Preferences {
     @DefaultBoolean(true)
     boolean settings_stable_channel();
 
+    @DefaultBoolean(false)
+    boolean settings_enable_updates();
+
     String browserRootFolder();
 
     @DefaultInt(200)

--- a/app/src/main/java/com/hiddenramblings/tagmo/settings/SettingsFragment.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/settings/SettingsFragment.java
@@ -87,6 +87,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     ListPreference imageNetworkSetting;
     CheckBoxPreference disableDebug;
     CheckBoxPreference stableChannel;
+    CheckBoxPreference enableUpdates;
 
     private KeyManager keyManager;
     private AmiiboManager amiiboManager = null;
@@ -128,10 +129,12 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         imageNetworkSetting = findPreference(getString(R.string.image_network_settings));
         disableDebug = findPreference(getString(R.string.settings_disable_debug));
         stableChannel = findPreference(getString(R.string.settings_stable_channel));
+        enableUpdates = stableChannel = findPreference(getString(R.string.settings_enable_updates));
 
         this.enableTagTypeValidation.setChecked(prefs.enable_tag_type_validation().get());
         this.disableDebug.setChecked(prefs.settings_disable_debug().get());
         this.stableChannel.setChecked(prefs.settings_stable_channel().get());
+        this.enableUpdates.setChecked(prefs.settings_enable_updates().get());
 
         loadAmiiboManager();
         updateKeySummary();
@@ -352,6 +355,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         });
         stableChannel.setOnPreferenceClickListener(preference -> {
             prefs.settings_stable_channel().put(stableChannel.isChecked());
+            return SettingsFragment.super.onPreferenceTreeClick(preference);
+        });
+        enableUpdates.setOnPreferenceClickListener(preference -> {
+            prefs.settings_enable_updates().put(enableUpdates.isChecked());
             return SettingsFragment.super.onPreferenceTreeClick(preference);
         });
 

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -31,6 +31,7 @@
     <string name="settings_import_info_amiiboapi">settings_sync_info_amiiboapi</string>
     <string name="settings_disable_debug">settings_disable_debug</string>
     <string name="settings_stable_channel">settings_stable_channel</string>
+    <string name="settings_enable_updates">settings_enable_updates</string>
     <string name="settings_view_guides">settings_view_guides</string>
     <string name="settings_sponsor_dev">settings_sponsor_dev</string>
     <string name="image_network_settings">image_network_settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,7 +184,9 @@
     <string name="pref_disable_debug">Disable Debug Logger</string>
     <string name="disable_debug_details">May improve performance, but limits available details to resolve issues</string>
     <string name="pref_stable_channel">Stable Update Checks</string>
+    <string name="pref_enable_updates">Update Checks</string>
     <string name="stable_channel_details">Only check application updates from the stable release branch of TagMo</string>
+    <string name="settings_enable_updates_details">Check for TagMo application updates</string>
     <string name="pref_resources">Resources</string>
     <string name="pref_guides_link">Browse TagMo Guides</string>
     <string name="pref_donate_link">Sponsor Development</string>

--- a/app/src/main/res/xml/preference_screen.xml
+++ b/app/src/main/res/xml/preference_screen.xml
@@ -118,6 +118,12 @@
             android:title="@string/pref_disable_debug"
             app:iconSpaceReserved="false" />
         <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/settings_enable_updates"
+            android:summary="@string/settings_enable_updates_details"
+            android:title="@string/pref_enable_updates"
+            app:iconSpaceReserved="false" />
+        <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/settings_stable_channel"
             android:summary="@string/stable_channel_details"


### PR DESCRIPTION
I like to add a setting to prevent update checks and thus auto-updates at all.

This is needed for:
1. Avoiding Android from popping up the "Allow install from unknown sources" dialog for this app.
2. Prevent updates to newer less stable versions and let the user stay on a desired app version.

Tested on an older version e8c3e8d37ba99d46c439808e52b5c83f2ad855aa (which is not crashing like newer TagMo versions on my Samsung S7, Android 8.0):

1. Test with updates disabled as default
   * [x] install and open TagMo
   * [x] no "install from unknown sources" request appears
   * [x] app works as usual
2. Test enable updates
   * [x] open TagMo
   * [x] go to settings and **check** "enable updates"
   * [x] close the app **(!)**
   * [x] open the app
   * [x] "install from unknown sources" request appears as usual
3. Test disable updates
   * [x] open TagMo
   * [x] go to settings and **uncheck** "enable updates"
   * [x] close the app **(!)**
   * [x] open the app
   * [x] no "install from unknown sources" request appears.

