### PR TITLE
Read strings as null-terminated strings

### DIFF
--- a/app/src/main/java/com/hiddenramblings/tagmo/amiibo/tagdata/AmiiboData.java
+++ b/app/src/main/java/com/hiddenramblings/tagmo/amiibo/tagdata/AmiiboData.java
@@ -409,7 +409,18 @@ public class AmiiboData {
 
     private static String getString(ByteBuffer bb, int offset, int length, Charset charset)
             throws UnsupportedEncodingException {
-        return charset.decode(ByteBuffer.wrap(getBytes(bb, offset, length))).toString();
+        bb.position(offset);
+        
+        // Find the position of the first null terminator
+        int i;
+        if (charset == CharsetCompat.UTF_16BE || charset == CharsetCompat.UTF_16LE) {
+            for (i = 0; i < length / 2 && bb.getShort() != 0; i++);
+            i *= 2;
+        } else {
+            for (i = 0; i < length && bb.get() != 0; i++);
+        }
+
+        return charset.decode(ByteBuffer.wrap(getBytes(bb, offset, i))).toString();
     }
 
     private static void putString(ByteBuffer bb, int offset, int length, Charset charset, String text) {


### PR DESCRIPTION
Avoids issues like these:
**Before:**
![image](https://user-images.githubusercontent.com/12049776/190257400-87c75ebd-3ba4-4f0d-8d72-a70303259ad2.png)
**After:**
![image](https://user-images.githubusercontent.com/12049776/190257486-fe295ebc-c131-4580-b09c-1c01eeaeb3fd.png)
