### PR TITLE
Add ChameleonUltra as a BLE device (push amiibo to emulator slots)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,6 +167,10 @@ dependencies {
     implementation 'io.github.vicmikhailau:MaskedEditText:5.0.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
 
+    /* JVM unit tests for the ChameleonUltra protocol/codec/uploader (pure Kotlin) */
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
+
     /* Firebase */
     // implementation platform('com.google.firebase:firebase-bom:33.9.0')
     // implementation("com.google.firebase:firebase-appcheck-playintegrity")

--- a/app/src/main/java/com/hiddenramblings/tagmo/BrowserActivity.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/BrowserActivity.kt
@@ -2737,11 +2737,25 @@ class BrowserActivity : AppCompatActivity(), BrowserSettingsListener,
     private fun showGattPage(extras: Bundle) {
         val index = if (prefs.eliteEnabled()) 3 else 2
         pagerAdapter.gattSlots.arguments = extras
-        if (viewPager.currentItem != index) {
-            viewPager.setCurrentItem(index, false)
-        } else {
+        if (viewPager.currentItem == index) {
             pagerAdapter.gattSlots.processArguments()
+            return
         }
+        // Like showElitePage: after navigating to the GATT page, trigger processArguments once the
+        // scroll completes (otherwise the amiibo passed via "Export to GATT" is ignored).
+        if (TagMo.isUserInputEnabled) {
+            setScrollListener(object : ScrollListener {
+                override fun onScrollComplete() {
+                    pagerAdapter.gattSlots.processArguments()
+                    scrollListener = null
+                }
+            })
+        } else {
+            viewPager.postDelayed({
+                pagerAdapter.gattSlots.processArguments()
+            }, TagMo.uiDelay.toLong())
+        }
+        viewPager.setCurrentItem(index, false)
     }
 
     fun showElitePage(extras: Bundle) {

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/Nordic.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/Nordic.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 
 object Nordic {
     enum class DEVICE {
-        FLASK, SLIDE, BLUUP, LINK, LOOP, PIXL, PIXL_JS, PUCK, GATT;
+        FLASK, SLIDE, BLUUP, LINK, LOOP, PIXL, PIXL_JS, PUCK, CHAMELEON_ULTRA, GATT;
     }
 
     val NUS  = UUID.fromString("6e400001-b5a3-f393-e0a9-e50e24dcca9e")
@@ -36,6 +36,7 @@ object Nordic {
             DEVICE.PIXL -> context.getString(R.string.device_pixl)
             DEVICE.PIXL_JS -> context.getString(R.string.device_pixl)
             DEVICE.PUCK -> context.getString(R.string.device_puck)
+            DEVICE.CHAMELEON_ULTRA -> context.getString(R.string.device_chameleon_ultra)
             else -> context.getString(R.string.unknown)
         }
     }

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/ChameleonBleTransport.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/ChameleonBleTransport.kt
@@ -1,0 +1,263 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import com.hiddenramblings.tagmo.bluetooth.GattArray.toPortions
+import com.hiddenramblings.tagmo.bluetooth.Nordic
+import com.hiddenramblings.tagmo.bluetooth.chameleon.protocol.ChameleonFrame
+import com.hiddenramblings.tagmo.bluetooth.chameleon.protocol.ChameleonProtocolException
+import com.hiddenramblings.tagmo.bluetooth.chameleon.protocol.ChameleonTransport
+import com.hiddenramblings.tagmo.bluetooth.chameleon.protocol.IncrementalFrameReader
+import com.hiddenramblings.tagmo.eightbit.os.Version
+import java.util.UUID
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Real BLE transport to the ChameleonUltra. Implements [ChameleonTransport] over a dedicated GATT
+ * link on the NUS service (shared with TagMo's other BLE devices: [Nordic.NUS]).
+ *
+ * - Send: the encoded frame is split into MTU-3 chunks written to [Nordic.TX] (6e400002).
+ * - Receive: notifications on [Nordic.RX] (6e400003) feed an [IncrementalFrameReader] that
+ *   reassembles frame(s); the first complete frame resolves the in-flight command.
+ * - Correlation: one command in flight at a time (serialized by [mutex]) + per-command timeout.
+ *
+ * Kept separate from TagMo's legacy `GattService` (text-based Flask/Puck protocols) because the
+ * Chameleon uses a distinct binary framing. BLE permissions are handled upstream (see BluetoothHandler).
+ *
+ * Timing constants (target MTU, inter-chunk delay, timeouts) are conservative and centralized below.
+ *
+ * Threading: GATT callbacks run on a binder thread, send()/connect() on a coroutine. Fields shared
+ * across the two are @Volatile, and access to the non-thread-safe [reader] is synchronized on it.
+ */
+@SuppressLint("MissingPermission")
+class ChameleonBleTransport(
+    private val context: Context,
+    private val onDisconnect: () -> Unit = {},
+) : ChameleonTransport {
+
+    @Volatile private var gatt: BluetoothGatt? = null
+    @Volatile private var writeChar: BluetoothGattCharacteristic? = null
+    @Volatile private var notifyChar: BluetoothGattCharacteristic? = null
+
+    private val reader = IncrementalFrameReader()
+    private val mutex = Mutex()
+
+    @Volatile private var mtuPayload = DEFAULT_MTU_PAYLOAD       // MTU - 3
+    @Volatile private var pending: CompletableDeferred<ChameleonFrame>? = null
+    /** CMD of the in-flight request: a notification only resolves it if the response echoes this CMD. */
+    @Volatile private var expectedCmd: Int = -1
+    @Volatile private var writeAck: CompletableDeferred<Unit>? = null
+    @Volatile private var connectDeferred: CompletableDeferred<Unit>? = null
+    /** True when the write characteristic supports WRITE (with response): each chunk awaits its ack. */
+    @Volatile private var useWriteResponse = false
+
+    /** Connect, discover services, enable notifications and negotiate MTU. Suspends until ready. */
+    suspend fun connect(device: BluetoothDevice) = mutex.withLock {
+        val deferred = CompletableDeferred<Unit>()
+        connectDeferred = deferred
+        gatt = device.connectGatt(context, false, callback)
+        withTimeout(CONNECT_TIMEOUT_MS) { deferred.await() }
+    }
+
+    override suspend fun send(request: ByteArray): ChameleonFrame = mutex.withLock {
+        val g = gatt ?: throw ChameleonProtocolException("transport not connected")
+        val tx = writeChar ?: throw ChameleonProtocolException("write characteristic missing")
+        synchronized(reader) { reader.reset() }
+        expectedCmd = ChameleonFrame.decode(request).getOrNull()?.cmd ?: -1
+        val deferred = CompletableDeferred<ChameleonFrame>()
+        pending = deferred
+        try {
+            for (chunk in request.toPortions(mtuPayload)) {
+                writeChunk(g, tx, chunk)
+            }
+            withTimeout(COMMAND_TIMEOUT_MS) { deferred.await() }
+        } finally {
+            pending = null
+        }
+    }
+
+    fun close() {
+        pending?.cancel()
+        writeAck?.cancel()
+        connectDeferred?.cancel()   // unblock a connect() still awaiting (e.g. user left mid-connect)
+        try { gatt?.disconnect() } catch (_: Exception) { }
+        try { gatt?.close() } catch (_: Exception) { }
+        gatt = null
+        writeChar = null
+        notifyChar = null
+        synchronized(reader) { reader.reset() }
+    }
+
+    private suspend fun writeChunk(g: BluetoothGatt, tx: BluetoothGattCharacteristic, chunk: ByteArray) {
+        if (useWriteResponse) {
+            // Write WITH response: wait for onCharacteristicWrite before the next chunk
+            // (reliable, no guessed delay). Falls back to timeout if the ack never arrives.
+            val ack = CompletableDeferred<Unit>()
+            writeAck = ack
+            doWrite(g, tx, chunk, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
+            try {
+                withTimeout(WRITE_TIMEOUT_MS) { ack.await() }
+            } finally {
+                writeAck = null
+            }
+        } else {
+            // Fallback WITHOUT response: small inter-chunk delay.
+            doWrite(g, tx, chunk, BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE)
+            delay(CHUNK_DELAY_MS)
+        }
+    }
+
+    private fun doWrite(g: BluetoothGatt, tx: BluetoothGattCharacteristic, chunk: ByteArray, type: Int) {
+        if (Version.isTiramisu) {
+            g.writeCharacteristic(tx, chunk, type)
+        } else @Suppress("deprecation") {
+            tx.writeType = type
+            tx.value = chunk
+            g.writeCharacteristic(tx)
+        }
+    }
+
+    private fun onNotify(value: ByteArray) {
+        val frames = synchronized(reader) { reader.append(value) }
+        val d = pending ?: return
+        // Only resolve with a frame echoing the in-flight CMD; ignore stale/spurious frames
+        // (e.g. a late response from a previously timed-out command).
+        frames.firstOrNull { it.cmd == expectedCmd }?.let { if (!d.isCompleted) d.complete(it) }
+    }
+
+    private fun enableNotifications(g: BluetoothGatt) {
+        val notify = notifyChar ?: run {
+            connectDeferred?.takeIf { !it.isCompleted }?.completeExceptionally(
+                ChameleonProtocolException("notification characteristic missing"),
+            )
+            return
+        }
+        g.setCharacteristicNotification(notify, true)
+        val cccd = notify.getDescriptor(CCCD) ?: run {
+            // No CCCD descriptor: best effort, consider the link ready.
+            connectDeferred?.takeIf { !it.isCompleted }?.complete(Unit)
+            return
+        }
+        val enable = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+        if (Version.isTiramisu) {
+            g.writeDescriptor(cccd, enable)
+        } else @Suppress("deprecation") {
+            cccd.value = enable
+            g.writeDescriptor(cccd)
+        }
+    }
+
+    private fun failConnect(message: String) {
+        connectDeferred?.takeIf { !it.isCompleted }
+            ?.completeExceptionally(ChameleonProtocolException(message))
+    }
+
+    private val callback = object : BluetoothGattCallback() {
+        override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
+            when (newState) {
+                BluetoothProfile.STATE_CONNECTED -> g.discoverServices()
+                BluetoothProfile.STATE_DISCONNECTED -> {
+                    pending?.cancel()
+                    writeAck?.cancel()
+                    failConnect("BLE link lost")
+                    onDisconnect()
+                }
+            }
+        }
+
+        // One GATT operation at a time: SERIALIZE
+        // discoverServices -> requestMtu -> (onMtuChanged) CCCD -> (onDescriptorWrite) ready.
+        override fun onServicesDiscovered(g: BluetoothGatt, status: Int) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                failConnect("service discovery failed: status=$status")
+                return
+            }
+            val service = g.getService(Nordic.NUS)
+            writeChar = service?.getCharacteristic(Nordic.TX)
+            notifyChar = service?.getCharacteristic(Nordic.RX)
+            val write = writeChar
+            if (write == null || notifyChar == null) {
+                failConnect("NUS service/characteristic not found")
+                return
+            }
+            // Prefer write WITH response if the characteristic advertises it (more reliable),
+            // otherwise fall back to write WITHOUT response.
+            useWriteResponse = (write.properties and BluetoothGattCharacteristic.PROPERTY_WRITE) != 0
+            // 1) MTU first; notifications are enabled in onMtuChanged.
+            if (!g.requestMtu(REQUESTED_MTU)) enableNotifications(g)
+        }
+
+        override fun onMtuChanged(g: BluetoothGatt, mtu: Int, status: Int) {
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                mtuPayload = (mtu - 3).coerceAtLeast(MIN_MTU_PAYLOAD)
+            }
+            // 2) Once MTU is set, enable notifications (next GATT op) regardless of MTU outcome.
+            enableNotifications(g)
+        }
+
+        override fun onDescriptorWrite(
+            g: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int,
+        ) {
+            // 3) CCCD written -> notifications active -> connection ready.
+            if (descriptor.uuid == CCCD) {
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    connectDeferred?.takeIf { !it.isCompleted }?.complete(Unit)
+                } else {
+                    failConnect("CCCD write failed: status=$status")
+                }
+            }
+        }
+
+        override fun onCharacteristicWrite(
+            g: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int,
+        ) {
+            // Ack of a written chunk (WRITE_TYPE_DEFAULT mode): unblocks the next chunk.
+            if (characteristic.uuid != Nordic.TX) return
+            val ack = writeAck?.takeIf { !it.isCompleted } ?: return
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                ack.complete(Unit)
+            } else {
+                ack.completeExceptionally(ChameleonProtocolException("chunk write failed: status=$status"))
+            }
+        }
+
+        // API 33+
+        override fun onCharacteristicChanged(
+            g: BluetoothGatt, characteristic: BluetoothGattCharacteristic, value: ByteArray,
+        ) {
+            if (characteristic.uuid == Nordic.RX) onNotify(value)
+        }
+
+        // API <= 32
+        @Deprecated("Deprecated in Java")
+        override fun onCharacteristicChanged(
+            g: BluetoothGatt, characteristic: BluetoothGattCharacteristic,
+        ) {
+            if (characteristic.uuid == Nordic.RX) {
+                @Suppress("deprecation")
+                characteristic.value?.let { onNotify(it) }
+            }
+        }
+    }
+
+    companion object {
+        private val CCCD: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+        private const val REQUESTED_MTU = 247
+        private const val DEFAULT_MTU_PAYLOAD = 20   // MTU 23 - 3 (before negotiation)
+        private const val MIN_MTU_PAYLOAD = 20
+        private const val CHUNK_DELAY_MS = 15L
+        private const val WRITE_TIMEOUT_MS = 3_000L
+        private const val COMMAND_TIMEOUT_MS = 5_000L
+        private const val CONNECT_TIMEOUT_MS = 15_000L
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/ChameleonClient.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/ChameleonClient.kt
@@ -1,0 +1,41 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon
+
+import android.bluetooth.BluetoothDevice
+import android.content.Context
+import com.hiddenramblings.tagmo.bluetooth.chameleon.protocol.AppVersion
+import com.hiddenramblings.tagmo.bluetooth.chameleon.protocol.ChameleonUploader
+
+/**
+ * High-level facade combining the BLE transport and the upload orchestrator.
+ * Single entry point for the UI layer: connect, read the version, push a dump.
+ *
+ * Typical usage (from a coroutine):
+ * ```
+ * val client = ChameleonClient(context) { /* on disconnect */ }
+ * client.connect(device)
+ * val version = client.getAppVersion()        // compatibility gate
+ * client.uploadAmiibo(dump540, slot) { done, total -> /* progress */ }
+ * client.close()
+ * ```
+ */
+class ChameleonClient(
+    context: Context,
+    onDisconnect: () -> Unit = {},
+) {
+    private val transport = ChameleonBleTransport(context, onDisconnect)
+    private val uploader = ChameleonUploader(transport)
+
+    suspend fun connect(device: BluetoothDevice) = transport.connect(device)
+
+    /** Firmware application version (to compare against the minimum supported — compatibility gate). */
+    suspend fun getAppVersion(): AppVersion = uploader.getAppVersion()
+
+    /** Pushes an NTAG215 dump (540 bytes) into [slot] (0..7), preserving the original UID. */
+    suspend fun uploadAmiibo(
+        dump: ByteArray,
+        slot: Int,
+        onProgress: (written: Int, total: Int) -> Unit = { _, _ -> },
+    ) = uploader.uploadAmiibo(dump, slot, onProgress = onProgress)
+
+    fun close() = transport.close()
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonCommands.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonCommands.kt
@@ -1,0 +1,128 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * Command builders: each function returns an encoded frame (ByteArray) ready to send.
+ * Built on top of the [ChameleonFrame] codec. No Android/BLE dependency.
+ *
+ * Convention: STATUS = 0 (client -> device direction).
+ */
+object ChameleonCommands {
+
+    /** GET_APP_VERSION — no data. */
+    fun getAppVersion(): ByteArray = ChameleonFrame.encode(Command.GET_APP_VERSION)
+
+    /** SET_ACTIVE_SLOT — payload: slot(1). */
+    fun setActiveSlot(slot: Int): ByteArray {
+        ChameleonProtocol.requireValidSlot(slot)
+        return ChameleonFrame.encode(Command.SET_ACTIVE_SLOT, byteArrayOf(slot.toByte()))
+    }
+
+    /** SET_SLOT_TAG_TYPE — payload: slot(1) | tagType(2, U16 big-endian). */
+    fun setSlotTagType(slot: Int, tagType: Int): ByteArray {
+        ChameleonProtocol.requireValidSlot(slot)
+        require(tagType in 0..0xFFFF) { "tagType out of U16 range: $tagType" }
+        val data = byteArrayOf(slot.toByte(), (tagType ushr 8).toByte(), tagType.toByte())
+        return ChameleonFrame.encode(Command.SET_SLOT_TAG_TYPE, data)
+    }
+
+    /** SET_SLOT_ENABLE — payload: slot(1) | senseType(1) | enable(1). */
+    fun setSlotEnable(slot: Int, senseType: Int, enable: Boolean): ByteArray {
+        ChameleonProtocol.requireValidSlot(slot)
+        require(senseType in 0..0xFF) { "senseType out of byte range: $senseType" }
+        val data = byteArrayOf(slot.toByte(), senseType.toByte(), if (enable) 1 else 0)
+        return ChameleonFrame.encode(Command.SET_SLOT_ENABLE, data)
+    }
+
+    /** Convenience: configure the slot as NTAG215. */
+    fun setSlotNtag215(slot: Int): ByteArray =
+        setSlotTagType(slot, ChameleonProtocol.TAG_TYPE_NTAG215)
+
+    /** Convenience: enable/disable the slot's HF part. */
+    fun setHfSlotEnabled(slot: Int, enable: Boolean = true): ByteArray =
+        setSlotEnable(slot, ChameleonProtocol.SENSE_HF, enable)
+
+    /**
+     * Writes a block of emulator pages (eload).
+     * Layout (chameleon_cmd.py:1279-1290): data = startPage(1) | pageCount(1) | pages[pageCount * 4].
+     */
+    fun writeEmuPages(startPage: Int, pages: ByteArray): ByteArray {
+        require(pages.isNotEmpty() && pages.size % ChameleonProtocol.NTAG215_PAGE_SIZE == 0) {
+            "pages must be a multiple of ${ChameleonProtocol.NTAG215_PAGE_SIZE} bytes"
+        }
+        val count = pages.size / ChameleonProtocol.NTAG215_PAGE_SIZE
+        // Firmware constraint: startPage + count <= 256.
+        require(startPage in 0..0xFF && startPage + count <= 256) {
+            "startPage/pageCount out of range (startPage=$startPage, count=$count)"
+        }
+        val data = ByteArray(2 + pages.size)
+        data[0] = startPage.toByte()
+        data[1] = count.toByte()
+        pages.copyInto(data, 2)
+        return ChameleonFrame.encode(Command.MF0_NTAG_WRITE_EMU_PAGE_DATA, data)
+    }
+
+    /** Persists the slots configuration to flash. */
+    fun saveSlotConfig(): ByteArray = ChameleonFrame.encode(Command.SLOT_DATA_CONFIG_SAVE)
+
+    /** SET_SLOT_DATA_DEFAULT — reset slot data to the type default. payload: slot(1) | tagType(2 BE). */
+    fun setSlotDataDefault(slot: Int, tagType: Int = ChameleonProtocol.TAG_TYPE_NTAG215): ByteArray {
+        ChameleonProtocol.requireValidSlot(slot)
+        require(tagType in 0..0xFFFF) { "tagType out of U16 range: $tagType" }
+        val data = byteArrayOf(slot.toByte(), (tagType ushr 8).toByte(), tagType.toByte())
+        return ChameleonFrame.encode(Command.SET_SLOT_DATA_DEFAULT, data)
+    }
+
+    /** MF0_NTAG_SET_VERSION_DATA — emulated GET_VERSION response (8 bytes). */
+    fun setVersionData(version: ByteArray = ChameleonProtocol.NTAG215_VERSION): ByteArray {
+        require(version.size == 8) { "version must be 8 bytes" }
+        return ChameleonFrame.encode(Command.MF0_NTAG_SET_VERSION_DATA, version)
+    }
+
+    /** MF0_NTAG_SET_SIGNATURE_DATA — emulated READ_SIG originality signature (32 bytes). */
+    fun setSignatureData(signature: ByteArray): ByteArray {
+        require(signature.size == ChameleonProtocol.NTAG215_SIGNATURE_SIZE) {
+            "signature must be ${ChameleonProtocol.NTAG215_SIGNATURE_SIZE} bytes"
+        }
+        return ChameleonFrame.encode(Command.MF0_NTAG_SET_SIGNATURE_DATA, signature)
+    }
+
+    /** MF0_NTAG_SET_WRITE_MODE — payload: mode(1). */
+    fun setWriteMode(mode: Int): ByteArray {
+        require(mode in 0..0xFF) { "mode out of byte range: $mode" }
+        return ChameleonFrame.encode(Command.MF0_NTAG_SET_WRITE_MODE, byteArrayOf(mode.toByte()))
+    }
+
+    /** MF0_NTAG_SET_UID_MAGIC_MODE — payload: enabled(1). */
+    fun setUidMagicMode(enabled: Boolean): ByteArray =
+        ChameleonFrame.encode(Command.MF0_NTAG_SET_UID_MAGIC_MODE, byteArrayOf(if (enabled) 1 else 0))
+
+    /**
+     * HF14A_SET_ANTI_COLL_DATA — sets the emulated UID/ATQA/SAK/ATS so the tag broadcasts the right UID.
+     * payload: uidLen(1) | uid | atqa(2) | sak(1) | atsLen(1) | ats   (chameleon_cmd.py:1334)
+     */
+    fun setAntiCollision(
+        uid: ByteArray,
+        atqa: ByteArray = ChameleonProtocol.NTAG215_ATQA,
+        sak: Int = ChameleonProtocol.NTAG215_SAK,
+        ats: ByteArray = ByteArray(0),
+    ): ByteArray {
+        require(uid.isNotEmpty() && uid.size <= 0xFF) { "uid length out of range: ${uid.size}" }
+        require(atqa.size == 2) { "atqa must be 2 bytes" }
+        require(sak in 0..0xFF && ats.size <= 0xFF) { "sak/ats out of range" }
+        val data = ByteArray(1 + uid.size + 2 + 1 + 1 + ats.size)
+        var o = 0
+        data[o++] = uid.size.toByte()
+        uid.copyInto(data, o); o += uid.size
+        atqa.copyInto(data, o); o += 2
+        data[o++] = sak.toByte()
+        data[o++] = ats.size.toByte()
+        ats.copyInto(data, o)
+        return ChameleonFrame.encode(Command.HF14A_SET_ANTI_COLL_DATA, data)
+    }
+
+    /** Extracts the 7-byte NTAG215 UID from a dump: pages 0-1 minus BCC0 (byte index 3). */
+    fun ntag215Uid(dump: ByteArray): ByteArray {
+        require(dump.size >= 8) { "dump too short for UID: ${dump.size}" }
+        return byteArrayOf(dump[0], dump[1], dump[2], dump[4], dump[5], dump[6], dump[7])
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonFrame.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonFrame.kt
@@ -1,0 +1,131 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * Result of incrementally parsing a frame from a possibly partial/noisy buffer.
+ */
+sealed interface ParseOutcome {
+    /** Not enough bytes to decide: wait for more. */
+    object NeedMore : ParseOutcome
+
+    /** Complete and valid frame extracted; [consumed] bytes to remove from the buffer. */
+    data class Ok(val frame: ChameleonFrame, val consumed: Int) : ParseOutcome
+
+    /** Invalid leading bytes; resynchronize by skipping [resync] bytes. */
+    data class Corrupt(val reason: String, val resync: Int) : ParseOutcome
+}
+
+/**
+ * A decoded ChameleonUltra frame. CMD/STATUS are U16 (0..65535).
+ *
+ * Format (verified, see docs/03):
+ *   [0]   SOF   = 0x11
+ *   [1]   LRC1  = LRC(SOF) = 0xEF
+ *   [2..3]CMD    (big-endian)
+ *   [4..5]STATUS (big-endian; client->device = 0x0000)
+ *   [6..7]LEN    (big-endian; DATA length, max 512)
+ *   [8]   LRC2  = LRC(CMD|STATUS|LEN)
+ *   [9..] DATA  (LEN bytes)
+ *   [..]  LRC3  = LRC(DATA)
+ * Total size = LEN + 10 (between 10 and 522).
+ */
+class ChameleonFrame(
+    val cmd: Int,
+    val status: Int,
+    val data: ByteArray,
+) {
+    init {
+        require(cmd in 0..0xFFFF) { "cmd out of U16 range" }
+        require(status in 0..0xFFFF) { "status out of U16 range" }
+        require(data.size <= MAX_DATA) { "DATA > $MAX_DATA" }
+    }
+
+    /** Serializes this frame. (STATUS kept as-is — for a client->device send, use 0.) */
+    fun encode(): ByteArray = encode(cmd, status, data)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ChameleonFrame) return false
+        return cmd == other.cmd && status == other.status && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int =
+        (cmd * 31 + status) * 31 + data.contentHashCode()
+
+    override fun toString(): String =
+        "ChameleonFrame(cmd=$cmd, status=$status, data=${data.joinToString("") { "%02x".format(it) }})"
+
+    companion object {
+        const val SOF: Byte = 0x11
+        const val LRC1: Int = 0xEF          // = LRC(SOF)
+        const val HEADER_SIZE: Int = 9      // SOF,LRC1,CMD2,STATUS2,LEN2,LRC2 -> DATA starts at index 9
+        const val OVERHEAD: Int = 10        // header + LRC3
+        const val MAX_DATA: Int = 512
+        const val MAX_FRAME: Int = MAX_DATA + OVERHEAD
+
+        /** Builds a frame from a typed command (STATUS=0, client->device direction). */
+        fun encode(command: Command, data: ByteArray = ByteArray(0)): ByteArray =
+            encode(command.code, 0, data)
+
+        /** Builds a raw frame. */
+        fun encode(cmd: Int, status: Int = 0, data: ByteArray = ByteArray(0)): ByteArray {
+            require(cmd in 0..0xFFFF) { "cmd out of U16 range" }
+            require(status in 0..0xFFFF) { "status out of U16 range" }
+            require(data.size <= MAX_DATA) { "DATA > $MAX_DATA" }
+            val len = data.size
+            val out = ByteArray(len + OVERHEAD)
+            out[0] = SOF
+            out[1] = Lrc.compute(out, 0, 1).toByte()        // over SOF -> 0xEF
+            out[2] = (cmd ushr 8).toByte(); out[3] = cmd.toByte()
+            out[4] = (status ushr 8).toByte(); out[5] = status.toByte()
+            out[6] = (len ushr 8).toByte(); out[7] = len.toByte()
+            out[8] = Lrc.compute(out, 2, 8).toByte()        // over CMD|STATUS|LEN
+            data.copyInto(out, 9)
+            out[9 + len] = Lrc.compute(out, 9, 9 + len).toByte() // over DATA
+            return out
+        }
+
+        /**
+         * Tries to parse ONE frame from [buf] at offset [off] over [len] available bytes.
+         * Does not throw: returns NeedMore / Ok / Corrupt. Used by IncrementalFrameReader.
+         */
+        fun tryParse(buf: ByteArray, off: Int, len: Int): ParseOutcome {
+            if (len < 1) return ParseOutcome.NeedMore
+            if (buf[off] != SOF) return ParseOutcome.Corrupt("expected SOF 0x11", 1)
+            if (len < HEADER_SIZE) return ParseOutcome.NeedMore
+            if ((buf[off + 1].toInt() and 0xFF) != LRC1) return ParseOutcome.Corrupt("invalid LRC1", 1)
+
+            val cmd = u16(buf, off + 2)
+            val status = u16(buf, off + 4)
+            val dlen = u16(buf, off + 6)
+            if (dlen > MAX_DATA) return ParseOutcome.Corrupt("LEN > $MAX_DATA", 1)
+
+            val lrc2 = Lrc.compute(buf, off + 2, off + 8)
+            if ((buf[off + 8].toInt() and 0xFF) != lrc2) return ParseOutcome.Corrupt("invalid LRC2", 1)
+
+            val total = dlen + OVERHEAD
+            if (len < total) return ParseOutcome.NeedMore
+
+            val dataStart = off + 9
+            val lrc3 = Lrc.compute(buf, dataStart, dataStart + dlen)
+            if ((buf[dataStart + dlen].toInt() and 0xFF) != lrc3) return ParseOutcome.Corrupt("invalid LRC3", 1)
+
+            val data = buf.copyOfRange(dataStart, dataStart + dlen)
+            return ParseOutcome.Ok(ChameleonFrame(cmd, status, data), total)
+        }
+
+        /**
+         * Decodes a frame assumed to be complete and standalone. Fails if incomplete, corrupt, or with extra bytes.
+         */
+        fun decode(bytes: ByteArray): Result<ChameleonFrame> =
+            when (val o = tryParse(bytes, 0, bytes.size)) {
+                is ParseOutcome.Ok ->
+                    if (o.consumed == bytes.size) Result.success(o.frame)
+                    else Result.failure(IllegalArgumentException("extra bytes after frame"))
+                ParseOutcome.NeedMore -> Result.failure(IllegalArgumentException("incomplete frame"))
+                is ParseOutcome.Corrupt -> Result.failure(IllegalArgumentException(o.reason))
+            }
+
+        private fun u16(buf: ByteArray, i: Int): Int =
+            ((buf[i].toInt() and 0xFF) shl 8) or (buf[i + 1].toInt() and 0xFF)
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonProtocol.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonProtocol.kt
@@ -1,0 +1,38 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * Protocol constants and small guards. Values are extracted from pinned upstream sources
+ * (chameleon_enum.py @ ChameleonUltra 6e2a902d); see constants/chameleon-extracted.md for provenance.
+ */
+object ChameleonProtocol {
+
+    // --- NTAG215 facts (NXP NTAG21x datasheet) ---
+    const val NTAG215_PAGE_SIZE: Int = 4
+    const val NTAG215_PAGE_COUNT: Int = 135
+    const val NTAG215_DUMP_SIZE: Int = NTAG215_PAGE_SIZE * NTAG215_PAGE_COUNT // 540
+
+    /** NTAG215 U16 value in `tag_specific_type_t`. */
+    const val TAG_TYPE_NTAG215: Int = 1101          // enum.py:348  (NTAG213=1100, NTAG216=1102)
+
+    /** HF `sense_type` in `tag_sense_type_t`. */
+    const val SENSE_HF: Int = 2                     // enum.py:281
+
+    /** NTAG215 originality signature length (READ_SIG), in bytes. */
+    const val NTAG215_SIGNATURE_SIZE: Int = 32
+
+    /** NTAG215 GET_VERSION response (8 bytes), used to make the emulator look like a genuine NTAG215. */
+    val NTAG215_VERSION: ByteArray = byteArrayOf(0x00, 0x04, 0x04, 0x02, 0x01, 0x00, 0x11, 0x03)
+
+    /** NTAG215 ISO14443-3 anti-collision values. */
+    val NTAG215_ATQA: ByteArray = byteArrayOf(0x44, 0x00)
+    const val NTAG215_SAK: Int = 0x00
+
+    /** Success status for general-config commands. */
+    const val STATUS_SUCCESS: Int = 0x68            // enum.py:203
+
+    /** The protocol numbers slots 0..7 (the CLI numbers them 1..8). */
+    fun requireValidSlot(slot: Int): Int {
+        require(slot in 0..7) { "slot out of protocol range 0..7: $slot" }
+        return slot
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonResponses.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonResponses.kt
@@ -1,0 +1,40 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/** Firmware application version, comparable (used for the firmware compatibility gate). */
+data class AppVersion(val major: Int, val minor: Int) : Comparable<AppVersion> {
+    override fun compareTo(other: AppVersion): Int =
+        if (major != other.major) major.compareTo(other.major) else minor.compareTo(other.minor)
+
+    override fun toString(): String = "$major.$minor"
+}
+
+/** Response parsers + status validation. */
+object ChameleonResponses {
+
+    /**
+     * Parses the GET_APP_VERSION response.
+     * Layout: `struct.unpack('!BB', data)` => data = [major, minor]
+     * (chameleon_cmd.py:29-35 @ ChameleonUltra 6e2a902d).
+     */
+    fun parseAppVersion(frame: ChameleonFrame): AppVersion {
+        require(frame.data.size >= 2) { "version response too short (${frame.data.size} bytes)" }
+        return AppVersion(frame.data[0].toInt() and 0xFF, frame.data[1].toInt() and 0xFF)
+    }
+
+    /**
+     * True if the response carries a success status.
+     *
+     * The amiibo flow only uses general-config commands (SET_ACTIVE_SLOT, SET_SLOT_TAG_TYPE,
+     * SET_SLOT_ENABLE, WRITE_EMU_PAGE_DATA, SLOT_DATA_CONFIG_SAVE, GET_APP_VERSION) which all reply
+     * with STATUS_SUCCESS (0x68). We deliberately do NOT accept HF_TAG_OK (0x00) here: 0x00 is the
+     * HF-operation success code, not returned by these commands, and accepting it would mask errors.
+     */
+    fun isSuccess(frame: ChameleonFrame): Boolean =
+        frame.status == ChameleonProtocol.STATUS_SUCCESS
+
+    /** Throws if the response is not a success. */
+    fun requireSuccess(frame: ChameleonFrame): ChameleonFrame {
+        require(isSuccess(frame)) { "non-success status: 0x%04X".format(frame.status) }
+        return frame
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonTransport.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonTransport.kt
@@ -1,0 +1,19 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * Abstraction of the request->response link to the ChameleonUltra.
+ *
+ * The protocol is sequential: one command in flight at a time. The real implementation (BLE) lives
+ * on the Android side and builds on the codec; a fake is used for JVM tests.
+ * No Android dependency here: only `kotlinx.coroutines` (pure JVM) is required.
+ */
+interface ChameleonTransport {
+    /**
+     * Sends an already-encoded frame (see `ChameleonCommands` / `ChameleonFrame.encode`) and suspends
+     * until the complete (reassembled) response frame is received, or throws on timeout/error.
+     */
+    suspend fun send(request: ByteArray): ChameleonFrame
+}
+
+/** ChameleonUltra protocol/transport error (unexpected CMD, non-success status, timeout, link lost). */
+class ChameleonProtocolException(message: String) : Exception(message)

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonUploader.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonUploader.kt
@@ -1,0 +1,119 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * Orchestrates the amiibo upload flow to a ChameleonUltra, on top of a [ChameleonTransport].
+ * Pure code (no Android/BLE dependency): JVM-testable with a fake.
+ *
+ * Replicated sequence (matches the chameleon-ultra-amiibo reference app, so a strict reader such as a
+ * Switch accepts the emulated tag):
+ *   1. SET_ACTIVE_SLOT(slot)
+ *   2. SET_SLOT_TAG_TYPE(slot, NTAG215) + SET_SLOT_DATA_DEFAULT(slot, NTAG215)
+ *   3. SET_VERSION_DATA (NTAG215 GET_VERSION) ; SET_WRITE_MODE / SET_UID_MAGIC_MODE (best-effort)
+ *   4. SET_SIGNATURE_DATA (READ_SIG: from a 572-byte dump's trailing 32 bytes, else zeros)
+ *   5. WRITE_EMU_PAGE_DATA x blocks (the 135 pages)
+ *   6. SET_ANTI_COLL_DATA (the original UID from pages 0..1) — so the broadcast UID matches the
+ *      amiibo's UID-bound signature; omitting this makes a Switch report "not an amiibo"
+ *   7. SET_SLOT_ENABLE(slot, HF, true)
+ *   8. SLOT_DATA_CONFIG_SAVE() — otherwise lost on reboot
+ *
+ * Guardrails: NTAG215 dump (540 bytes) validated, UID preserved, no amiibo crypto (signature/version
+ * are the tag's own NTAG215 data, not amiibo keys).
+ *
+ * Not atomic: a mid-sequence failure (timeout, link loss) throws and leaves the slot partially written
+ * (the firmware offers no rollback); the caller surfaces the error and the user can retry the upload.
+ */
+class ChameleonUploader(private val transport: ChameleonTransport) {
+
+    /** Fetches and parses the application version (for the firmware compatibility gate). */
+    suspend fun getAppVersion(): AppVersion {
+        val resp = exec(ChameleonCommands.getAppVersion(), Command.GET_APP_VERSION)
+        return ChameleonResponses.parseAppVersion(resp)
+    }
+
+    /**
+     * Pushes [dump] (NTAG215, 540 bytes) into [slot] (0..7).
+     * @param pagesPerBlock number of pages per emulator write command.
+     * @param onProgress callback (written blocks, total) — emitted at start (0,total) then after each block.
+     */
+    suspend fun uploadAmiibo(
+        dump: ByteArray,
+        slot: Int,
+        pagesPerBlock: Int = DEFAULT_PAGES_PER_BLOCK,
+        onProgress: (written: Int, total: Int) -> Unit = { _, _ -> },
+    ) {
+        val signature = extractSignature(dump)
+        val data = PageChunker.normalizeToNtag215(dump)
+        ChameleonProtocol.requireValidSlot(slot)
+
+        exec(ChameleonCommands.setActiveSlot(slot), Command.SET_ACTIVE_SLOT)
+        exec(ChameleonCommands.setSlotNtag215(slot), Command.SET_SLOT_TAG_TYPE)
+        exec(ChameleonCommands.setSlotDataDefault(slot), Command.SET_SLOT_DATA_DEFAULT)
+        exec(ChameleonCommands.setVersionData(), Command.MF0_NTAG_SET_VERSION_DATA)
+        // Best-effort: some firmware revisions may not support these write-mode toggles.
+        execBestEffort(ChameleonCommands.setWriteMode(0), Command.MF0_NTAG_SET_WRITE_MODE)
+        execBestEffort(ChameleonCommands.setUidMagicMode(false), Command.MF0_NTAG_SET_UID_MAGIC_MODE)
+        exec(ChameleonCommands.setSignatureData(signature), Command.MF0_NTAG_SET_SIGNATURE_DATA)
+
+        val blocks = PageChunker.chunkByPages(data, pagesPerBlock)
+        onProgress(0, blocks.size)
+        blocks.forEachIndexed { index, block ->
+            exec(
+                ChameleonCommands.writeEmuPages(block.startPage, block.data),
+                Command.MF0_NTAG_WRITE_EMU_PAGE_DATA,
+            )
+            onProgress(index + 1, blocks.size)
+        }
+
+        // Set the emulated UID so the broadcast UID matches the amiibo's UID-bound signature.
+        exec(
+            ChameleonCommands.setAntiCollision(ChameleonCommands.ntag215Uid(data)),
+            Command.HF14A_SET_ANTI_COLL_DATA,
+        )
+        exec(ChameleonCommands.setHfSlotEnabled(slot, enable = true), Command.SET_SLOT_ENABLE)
+        exec(ChameleonCommands.saveSlotConfig(), Command.SLOT_DATA_CONFIG_SAVE)
+    }
+
+    /**
+     * READ_SIG signature for extended dumps: 32 bytes at offset 544 (540 pages + 4 counter bytes),
+     * matching the reference app; zeros otherwise (the Switch accepts a zero signature).
+     */
+    private fun extractSignature(dump: ByteArray): ByteArray {
+        val sigStart = ChameleonProtocol.NTAG215_DUMP_SIZE + 4
+        val sigEnd = sigStart + ChameleonProtocol.NTAG215_SIGNATURE_SIZE
+        return if (dump.size >= sigEnd) dump.copyOfRange(sigStart, sigEnd)
+        else ByteArray(ChameleonProtocol.NTAG215_SIGNATURE_SIZE)
+    }
+
+    /** Like [exec] but tolerates an unsupported/non-success command (firmware variance). */
+    private suspend fun execBestEffort(request: ByteArray, expected: Command) {
+        try {
+            exec(request, expected)
+        } catch (_: ChameleonProtocolException) {
+            // Command not supported or returned non-success on this firmware; safe to skip.
+        }
+    }
+
+    /** Sends a request, verifies the CMD echo then the success status; throws otherwise. */
+    private suspend fun exec(request: ByteArray, expected: Command): ChameleonFrame {
+        val resp = transport.send(request)
+        if (resp.cmd != expected.code) {
+            throw ChameleonProtocolException(
+                "unexpected response CMD: expected ${expected.code} (${expected.name}), got ${resp.cmd}",
+            )
+        }
+        if (!ChameleonResponses.isSuccess(resp)) {
+            throw ChameleonProtocolException(
+                "non-success status for ${expected.name}: 0x%04X".format(resp.status),
+            )
+        }
+        return resp
+    }
+
+    companion object {
+        /**
+         * Pages per WRITE_EMU command. Conservative value (128 data bytes + header, well under the
+         * 512 DATA limit and the firmware constraint page_start+count<=256).
+         */
+        const val DEFAULT_PAGES_PER_BLOCK = 32
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/Command.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/Command.kt
@@ -1,0 +1,26 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * ChameleonUltra protocol opcodes (CMD field, U16).
+ *
+ * Values are taken from chameleon_enum.py @ ChameleonUltra 6e2a902d; see
+ * constants/chameleon-extracted.md for full provenance (file:line@SHA).
+ */
+enum class Command(val code: Int) {
+    GET_APP_VERSION(1000),                  // enum.py:6
+    SET_ACTIVE_SLOT(1003),                  // enum.py:9
+    SET_SLOT_TAG_TYPE(1004),                // enum.py:10
+    SET_SLOT_DATA_DEFAULT(1005),            // enum.py:11  (reset slot data to type default)
+    SET_SLOT_ENABLE(1006),                  // enum.py:12
+    SLOT_DATA_CONFIG_SAVE(1009),            // enum.py:18  (persist slots config to flash)
+    HF14A_SET_ANTI_COLL_DATA(4001),         // enum.py:105 (emulated UID/ATQA/SAK/ATS)
+    MF0_NTAG_SET_UID_MAGIC_MODE(4020),      // enum.py:127
+    MF0_NTAG_WRITE_EMU_PAGE_DATA(4022),     // enum.py:129 (write emulator pages = eload)
+    MF0_NTAG_SET_VERSION_DATA(4024),        // enum.py:131 (GET_VERSION, 8 bytes)
+    MF0_NTAG_SET_SIGNATURE_DATA(4026),      // enum.py:133 (READ_SIG, 32 bytes)
+    MF0_NTAG_SET_WRITE_MODE(4032);          // enum.py:139
+
+    companion object {
+        fun fromCode(code: Int): Command? = entries.firstOrNull { it.code == code }
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/IncrementalFrameReader.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/IncrementalFrameReader.kt
@@ -1,0 +1,46 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * Reassembles ChameleonUltra frames from a byte stream arriving in chunks (BLE notifications).
+ * Handles: frames fragmented across multiple chunks, several frames within a single chunk, and
+ * leading garbage bytes (resynchronization on SOF).
+ *
+ * Not thread-safe: confine to a single thread/scope (callers synchronize external access).
+ */
+class IncrementalFrameReader {
+
+    private var buffer = ByteArray(0)
+
+    /** Bytes currently pending (partial frame not yet complete). */
+    val pending: Int get() = buffer.size
+
+    /**
+     * Appends a received chunk and returns the newly available complete frames (in order).
+     */
+    fun append(chunk: ByteArray): List<ChameleonFrame> {
+        if (chunk.isEmpty() && buffer.isEmpty()) return emptyList()
+        buffer += chunk
+
+        val frames = ArrayList<ChameleonFrame>()
+        var off = 0
+        loop@ while (off < buffer.size) {
+            when (val o = ChameleonFrame.tryParse(buffer, off, buffer.size - off)) {
+                ParseOutcome.NeedMore -> break@loop
+                is ParseOutcome.Ok -> {
+                    frames += o.frame
+                    off += o.consumed
+                }
+                is ParseOutcome.Corrupt -> off += o.resync
+            }
+        }
+
+        // Compact: keep only the unconsumed tail.
+        buffer = if (off == 0) buffer else buffer.copyOfRange(off, buffer.size)
+        return frames
+    }
+
+    /** Clears the buffer (e.g. after disconnect/reconnect). */
+    fun reset() {
+        buffer = ByteArray(0)
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/Lrc.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/Lrc.kt
@@ -1,0 +1,29 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/*
+ * Pure Kotlin, no Android/BLE dependency: JVM-testable.
+ * Frame format reference: docs/03-protocol-reference.md (verified against the official ChameleonUltra wiki).
+ */
+
+/**
+ * Longitudinal Redundancy Check as defined by the ChameleonUltra protocol:
+ * 8-bit two's complement of the sum of the covered bytes, modulo 2^8.
+ *
+ * Property: LRC(SOF=0x11) == 0xEF.
+ */
+internal object Lrc {
+
+    /**
+     * Computes the LRC over the range [fromIndex, toIndex) of [data].
+     * @return value 0..255.
+     */
+    fun compute(data: ByteArray, fromIndex: Int = 0, toIndex: Int = data.size): Int {
+        require(fromIndex in 0..data.size) { "fromIndex out of bounds" }
+        require(toIndex in fromIndex..data.size) { "toIndex out of bounds" }
+        var sum = 0
+        for (i in fromIndex until toIndex) {
+            sum = (sum + (data[i].toInt() and 0xFF)) and 0xFF
+        }
+        return (0x100 - sum) and 0xFF
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/PageChunker.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/PageChunker.kt
@@ -1,0 +1,73 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/** A block of consecutive pages to write in one emulator command. */
+class PageBlock(val startPage: Int, val data: ByteArray) {
+    val pageCount: Int get() = data.size / ChameleonProtocol.NTAG215_PAGE_SIZE
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PageBlock) return false
+        return startPage == other.startPage && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int = startPage * 31 + data.contentHashCode()
+    override fun toString(): String = "PageBlock(startPage=$startPage, pageCount=$pageCount)"
+}
+
+/**
+ * LOGICAL splitting of a dump into page blocks (protocol level).
+ *
+ * Independent of BLE/MTU chunking (handled by the transport). [pagesPerBlock] is dictated by the
+ * write command (protocol payload limit and/or firmware constraint).
+ */
+object PageChunker {
+
+    fun chunkByPages(
+        dump: ByteArray,
+        pagesPerBlock: Int,
+        pageSize: Int = ChameleonProtocol.NTAG215_PAGE_SIZE,
+    ): List<PageBlock> {
+        require(pageSize > 0) { "pageSize > 0" }
+        require(pagesPerBlock > 0) { "pagesPerBlock > 0" }
+        require(dump.size % pageSize == 0) { "dump size (${dump.size}) is not a multiple of pageSize ($pageSize)" }
+
+        val totalPages = dump.size / pageSize
+        val blocks = ArrayList<PageBlock>()
+        var page = 0
+        while (page < totalPages) {
+            val n = minOf(pagesPerBlock, totalPages - page)
+            val from = page * pageSize
+            blocks += PageBlock(page, dump.copyOfRange(from, from + n * pageSize))
+            page += n
+        }
+        return blocks
+    }
+
+    /** Checks that a dump is exactly NTAG215-sized (540 bytes). */
+    fun requireNtag215(dump: ByteArray): ByteArray {
+        require(dump.size == ChameleonProtocol.NTAG215_DUMP_SIZE) {
+            "expected NTAG215 dump = ${ChameleonProtocol.NTAG215_DUMP_SIZE} bytes, got ${dump.size}"
+        }
+        return dump
+    }
+
+    /**
+     * Normalizes an amiibo dump to 540 bytes (NTAG215), handling the common variants:
+     * - 540: complete, as-is;
+     * - 532: missing the last 2 pages (PWD 0x85 + PACK/RFUI 0x86) -> padded with 8 zero bytes
+     *   (no impact on emulated reads: amiibo do not use password auth);
+     * - > 540 (e.g. 572, with trailing extra data) -> truncated to the first 540 bytes
+     *   (the actual tag pages, UID included).
+     */
+    fun normalizeToNtag215(dump: ByteArray): ByteArray {
+        val full = ChameleonProtocol.NTAG215_DUMP_SIZE
+        return when {
+            dump.size == full -> dump
+            dump.size == full - 8 -> dump.copyOf(full)          // 532 -> 540 (PWD/PACK zeroed)
+            dump.size > full -> dump.copyOfRange(0, full)        // 568/572... -> 540
+            else -> throw IllegalArgumentException(
+                "unexpected NTAG215 dump size: ${dump.size} (expected 532, 540 or more)",
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hiddenramblings/tagmo/fragment/GattSlotFragment.kt
+++ b/app/src/main/java/com/hiddenramblings/tagmo/fragment/GattSlotFragment.kt
@@ -85,6 +85,8 @@ import com.hiddenramblings.tagmo.nfctech.TagArray
 import com.hiddenramblings.tagmo.nfctech.TagArray.toByteArray
 import com.hiddenramblings.tagmo.nfctech.TagArray.toHex
 import com.hiddenramblings.tagmo.nfctech.TagArray.withRandomSerials
+import com.hiddenramblings.tagmo.bluetooth.chameleon.ChameleonClient
+import androidx.lifecycle.lifecycleScope
 import com.hiddenramblings.tagmo.widget.Toasty
 import com.shawnlin.numberpicker.NumberPicker
 import kotlinx.coroutines.CoroutineScope
@@ -141,6 +143,9 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
     private var scanCallbackOmllbo: LeScanCallback? = null
     private var scanCallbackLegacy: LeScanCallback? = null
     private var serviceGatt: GattService? = null
+    private var chameleonClient: ChameleonClient? = null
+    private var chameleonSlotDialog: AlertDialog? = null
+    private var pendingUploadData: ByteArray? = null
     private var isServiceDiscovered = false
     private var deviceProfile: String? = null
     private var deviceAddress: String? = null
@@ -477,6 +482,25 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
                     switchDevices.isGone = true
                 }
             }
+            // The Chameleon has no GattService-style slot management: hide all the inert controls,
+            // keeping only the upload (write_slot_file) + disconnect.
+            if (deviceType == Nordic.DEVICE.CHAMELEON_ULTRA
+                && (sheet == SHEET.MENU || sheet == SHEET.AMIIBO)) {
+                createBlank?.isGone = true
+                resetDevice?.isGone = true
+                writeRandom?.isVisible = true            // "Clone with random serial" (TagMo generation)
+                eraseSlots?.isGone = true
+                writeSlots?.isGone = true               // "Device full"
+                sortModeLabel?.isGone = true
+                sortModeSpinner?.isGone = true
+                gattSlotCount.isGone = true
+                amiiboTile?.isGone = true                // "NFC Tag Name" slot navigators
+                amiiboCard?.isGone = true                // carte amiibo (ACTIVER/SUPPRIMER)
+                screenOptions?.isGone = true
+                switchMenuOptions?.isGone = true         // "N2 ELITE options" toggle
+                view?.findViewById<View>(R.id.device_portal)?.isGone = true
+                slotOptionsMenu?.isVisible = true        // conteneur du bouton d'upload
+            }
         }
     }
 
@@ -751,6 +775,7 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
                 it.startsWith("amiloop") -> Nordic.DEVICE.LOOP
                 it.startsWith("pixl.js") || it.startsWith("pixljs") || it.startsWith("pixl ") ->
                    Nordic.DEVICE.PIXL_JS
+                it.startsWith("chameleon") -> Nordic.DEVICE.CHAMELEON_ULTRA
                else -> Nordic.DEVICE.GATT
             }
         } ?: Nordic.DEVICE.GATT
@@ -964,6 +989,9 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
                     Nordic.DEVICE.PUCK -> {
                         serviceGatt?.uploadPuckAmiibo(data, gattSlotCount.value - 1)
                     }
+                    Nordic.DEVICE.CHAMELEON_ULTRA -> {
+                        uploadChameleonAmiibo(data)
+                    }
                     else -> {
 
                     }
@@ -998,6 +1026,9 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
                         }
                         Nordic.DEVICE.PUCK -> {
                             serviceGatt?.uploadPuckAmiibo(data, gattSlotCount.value - 1)
+                        }
+                        Nordic.DEVICE.CHAMELEON_ULTRA -> {
+                            uploadChameleonAmiibo(data)
                         }
                         else -> {
 
@@ -1096,6 +1127,10 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
     }
 
     private fun startGattService() {
+        if (deviceType == Nordic.DEVICE.CHAMELEON_ULTRA) {
+            connectChameleon()
+            return
+        }
         val service = Intent(requireContext(), GattService::class.java)
         requireContext().startService(service)
         requireContext().bindService(service, gattServerConn, Context.BIND_AUTO_CREATE)
@@ -1116,8 +1151,181 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
 
     fun disconnectService() {
         dismissSnackbarNotice(true)
+        chameleonSlotDialog?.dismiss()
+        chameleonSlotDialog = null
+        chameleonClient?.close()
+        chameleonClient = null
+        pendingUploadData = null
         serviceGatt?.disconnect()
         stopGattService()
+    }
+
+    /**
+     * Connexion native au ChameleonUltra via [ChameleonClient][com.hiddenramblings.tagmo.bluetooth.chameleon.ChameleonClient]
+     * (transport BLE binaire dédié, distinct du GattService texte). Réutilise le scan/sélecteur existant.
+     * Smoke test M3 inclus : getAppVersion() prouve le lien BLE et le framing.
+     */
+    @SuppressLint("MissingPermission")
+    private fun connectChameleon() {
+        val address = deviceAddress
+        val adapter = mBluetoothAdapter
+            ?: bluetoothHandler?.getBluetoothAdapter(requireContext())
+        val device = try {
+            if (address != null) adapter?.getRemoteDevice(address) else null
+        } catch (e: Exception) { Debug.warn(e); null }
+        if (device == null) {
+            Toasty(requireActivity()).Long(R.string.fail_no_device)
+            return
+        }
+        val client = ChameleonClient(requireContext().applicationContext) {
+            fragmentHandler.post { if (isFragmentVisible) onChameleonDisconnected() }
+        }
+        chameleonClient = client
+        // Lifecycle-scoped: auto-cancelled if the view is destroyed during the (up to 15s) connect,
+        // and each UI step is guarded by isAdded to avoid requireActivity()/requireView() crashes.
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                client.connect(device)
+                val version = client.getAppVersion()
+                withContext(Dispatchers.Main) {
+                    if (!isAdded) return@withContext
+                    dismissSnackbarNotice(true)
+                    isServiceDiscovered = true
+                    deviceType = Nordic.DEVICE.CHAMELEON_ULTRA
+                    // SHEET.MENU holds the "Upload binary to GATT device" button (write_slot_file),
+                    // the only relevant entry point for the Chameleon; onBottomSheetChanged hides the rest.
+                    onBottomSheetChanged(SHEET.MENU)
+                    requireView().findViewById<TextView>(R.id.hardware_info).text =
+                        "${deviceProfile ?: deviceType.logTag} (v$version)"
+                    // "Export to GATT" from the browser: upload the chosen amiibo directly
+                    // (slot picker only), without asking to re-select it.
+                    pendingUploadData?.let { data ->
+                        pendingUploadData = null
+                        uploadChameleonAmiibo(data)
+                    }
+                }
+            } catch (e: Exception) {
+                Debug.warn(e)
+                withContext(Dispatchers.Main) {
+                    if (!isAdded) return@withContext
+                    Toasty(requireActivity()).Short(Debug.getExceptionCause(e))
+                    onChameleonDisconnected()
+                }
+            }
+        }
+    }
+
+    private fun onChameleonDisconnected() {
+        chameleonClient?.close()
+        chameleonClient = null
+        pendingUploadData = null
+        isServiceDiscovered = false
+        deviceProfile = null
+        deviceAddress = null
+        deviceType = Nordic.DEVICE.GATT
+        onBottomSheetChanged(SHEET.LOCKED)
+        showDisconnectNotice()
+    }
+
+    /** Asks for the slot (0..7) then pushes the NTAG215 dump (540 bytes) via the uploader. */
+    private fun uploadChameleonAmiibo(tagData: ByteArray) {
+        val client = chameleonClient
+        if (null == client) {
+            processDialog?.dismiss()
+            Toasty(requireActivity()).Short(R.string.gatt_disconnect)
+            return
+        }
+        // The write_slot_file flow shows a notice BEFORE the slot is chosen: dismiss it while the
+        // user picks (otherwise a double dialog / progress without a slot).
+        processDialog?.dismiss()
+        val appContext = requireContext().applicationContext
+        val slotLabels = Array(8) { getString(R.string.chameleon_slot_label, it + 1) }
+        chameleonSlotDialog = AlertDialog.Builder(requireContext())
+            .setTitle(R.string.chameleon_slot_picker)
+            .setItems(slotLabels) { _, which ->
+                // "Clone with random serial": generated by TagMo (random UID + re-signing with the
+                // user's amiibo keys). Our code only transports the result.
+                val randomize = writeRandom?.isChecked == true
+                showProcessingNotice(NOTICE.UPLOAD)
+                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                    try {
+                        val payload: ByteArray = if (randomize) {
+                            val generated = tagData.withRandomSerials(1, keyManager).firstOrNull()
+                            if (null == generated) {
+                                withContext(Dispatchers.Main) {
+                                    if (!isAdded) return@withContext
+                                    processDialog?.dismiss()
+                                    Toasty(requireActivity()).Long(getString(R.string.chameleon_keys_required))
+                                }
+                                return@launch
+                            }
+                            // withRandomSerials returns DECRYPTED data (random UID patched in): it must be
+                            // re-encrypted/re-signed for the new UID (like TagWriter), otherwise the written
+                            // image is not a valid amiibo and no reader recognizes it.
+                            keyManager.encrypt(generated.array)
+                        } else {
+                            tagData
+                        }
+                        client.uploadAmiibo(amiiboPatchTo540(payload), which) { done, total ->
+                            // onProgress is not suspend: post the UI update on the main thread.
+                            // Use the application context: the fragment may be detached.
+                            fragmentHandler.post {
+                                processDialog?.setMessage(
+                                    appContext.getString(R.string.chameleon_upload_progress, which + 1, done, total)
+                                )
+                            }
+                        }
+                        withContext(Dispatchers.Main) {
+                            if (!isAdded) return@withContext
+                            processDialog?.dismiss()
+                            Toasty(requireActivity()).Short(
+                                getString(R.string.chameleon_upload_done, which + 1)
+                            )
+                        }
+                    } catch (e: Exception) {
+                        Debug.warn(e)
+                        withContext(Dispatchers.Main) {
+                            if (!isAdded) return@withContext
+                            processDialog?.dismiss()
+                            Toasty(requireActivity()).Short(Debug.getExceptionCause(e))
+                        }
+                    }
+                }
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    /**
+     * Amiibo-specific patch so a Switch accepts the emulated tag: ensures the NTAG215 password page
+     * (0x85, derived from the UID), PACK (0x86 = 80 80) and AUTH0 (0x04) are present. Mirrors the
+     * chameleon-ultra-amiibo reference (and TagMo's own write path) for 532-byte dumps that lack them.
+     */
+    private fun amiiboPatchTo540(dump: ByteArray): ByteArray {
+        val base = when {
+            dump.size >= 540 -> dump.copyOf(540)   // 540/572 -> first 540
+            dump.size == 532 -> dump.copyOf(540)    // pad; PWD/PACK filled below
+            else -> return dump                     // aberrant size: let the uploader validate/normalize
+        }
+        // AUTH0 (CFG0 byte 3, page 0x83): protect pages 4+ if unset.
+        if (base[527] == 0x00.toByte() || base[527] == 0xFF.toByte()) base[527] = 0x04
+        // If PACK already set (page 0x86 = 80 80), assume the password pages are valid.
+        if (base[536] == 0x80.toByte() && base[537] == 0x80.toByte()) return base
+        val uid = byteArrayOf(base[0], base[1], base[2], base[4], base[5], base[6], base[7])
+        amiiboKeygen(uid).copyInto(base, 532)       // page 0x85: PWD
+        base[536] = 0x80.toByte(); base[537] = 0x80.toByte(); base[538] = 0x00; base[539] = 0x00 // 0x86: PACK+RFU
+        return base
+    }
+
+    /** NTAG215 amiibo password derived from the 7-byte UID (public algorithm, from AmiiManage GPL). */
+    private fun amiiboKeygen(uid: ByteArray): ByteArray {
+        val u = IntArray(uid.size) { uid[it].toInt() and 0xFF }
+        return byteArrayOf(
+            (0xAA xor (u[1] xor u[3])).toByte(),
+            (0x55 xor (u[2] xor u[4])).toByte(),
+            (0xAA xor (u[3] xor u[5])).toByte(),
+            (0x55 xor (u[4] xor u[6])).toByte(),
+        )
     }
 
     @SuppressLint("MissingPermission")
@@ -1212,11 +1420,18 @@ open class GattSlotFragment : Fragment(), GattSlotAdapter.OnAmiiboClickListener,
                     if (isServiceDiscovered) {
                         try {
                             extras.getByteArray(NFCIntent.EXTRA_TAG_DATA)?.let {
-                                uploadAmiiboData(AmiiboData(it))
+                                if (deviceType == Nordic.DEVICE.CHAMELEON_ULTRA)
+                                    uploadChameleonAmiibo(it)        // direct: skip Amiibo resolution
+                                else
+                                    uploadAmiiboData(AmiiboData(it))
                             }
                         } catch (_: Exception) { }
                     } else {
-                        Toasty(requireActivity()).Long(R.string.fail_no_device)
+                        // Not connected yet (e.g. "Export to GATT" from the browser): remember the amiibo
+                        // and open device selection; the upload will start after connection
+                        // (see connectChameleon), without re-selection.
+                        pendingUploadData = extras.getByteArray(NFCIntent.EXTRA_TAG_DATA)
+                        selectBluetoothDevice()
                     }
                 }
             }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -220,6 +220,12 @@
 
     <string name="create_blank">Créer un Tag NFC virtuel vide</string>
     <string name="gatt_upload">Téléversement de binaire&#8230;</string>
+    <string name="chameleon_slot_picker">Choisir le slot Chameleon</string>
+    <string name="chameleon_slot_label">Slot %1$d</string>
+    <string name="chameleon_upload_done">Envoyé vers le slot Chameleon %1$d</string>
+    <string name="chameleon_upload_progress">Slot %1$d — bloc %2$d/%3$d</string>
+    <string name="chameleon_keys_required">Chargez vos clés amiibo dans TagMo pour générer un UID aléatoire</string>
+    <string name="fail_no_device">Aucun périphérique GATT connecté !</string>
     <string name="location_disclosure">L’emplacement est requis pour l’analyse Bluetooth LE. Conformément à la politique de Google Play, TagMo est tenu de vous informer que des données de localisation peuvent être collectées en arrière-plan. TagMo ne lit, ne stocke ni ne partage les données de localisation. En tant que tel, cet avis est strictement une formalité.</string>
 
     <string name="data_write">Données principales écrites</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -71,6 +71,7 @@
     <string name="device_loop" translatable="false">AmiLoop</string>
     <string name="device_pixl" translatable="false">Pixl.js</string>
     <string name="device_espruino" translatable="false">Espruino</string>
+    <string name="device_chameleon_ultra" translatable="false">Chameleon Ultra</string>
 
     <string name="mifare_classic" translatable="false">Mifare Classic</string>
     <string name="mifare_plus" translatable="false">Mifare Plus</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,6 +377,11 @@
     <string name="gatt_erase_confirm">Erase all slots from %1$s?</string>
     <string name="gatt_write_confirm">Write selections to %1$s?</string>
     <string name="gatt_upload">Uploading binary&#8230;</string>
+    <string name="chameleon_slot_picker">Select Chameleon slot</string>
+    <string name="chameleon_slot_label">Slot %1$d</string>
+    <string name="chameleon_upload_done">Sent to Chameleon slot %1$d</string>
+    <string name="chameleon_upload_progress">Slot %1$d — block %2$d/%3$d</string>
+    <string name="chameleon_keys_required">Load your amiibo keys in TagMo to generate a random serial</string>
     <string name="gatt_remove">Wiping slot data&#8230;</string>
     <string name="gatt_create">Creating blank tag&#8230;</string>
     <string name="gatt_format">Formatting device&#8230;</string>

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonCommandsTest.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonCommandsTest.kt
@@ -1,0 +1,94 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/*
+ * JUnit4. Requires TestHex.kt (same package & module) for `hex()`.
+ */
+class ChameleonCommandsTest {
+
+    // --- Verified layouts: frozen vectors ---
+
+    @Test
+    fun get_app_version() {
+        assertArrayEquals(hex("11 EF 03 E8 00 00 00 00 15 00"), ChameleonCommands.getAppVersion())
+    }
+
+    @Test
+    fun set_active_slot() {
+        assertArrayEquals(hex("11 EF 03 EB 00 00 00 01 11 03 FD"), ChameleonCommands.setActiveSlot(3))
+    }
+
+    @Test
+    fun set_slot_tag_type_generic() {
+        // explicit tagType 0x04E8 (example value, NOT the real NTAG215 value)
+        assertArrayEquals(
+            hex("11 EF 03 EC 00 00 00 03 0E 02 04 E8 12"),
+            ChameleonCommands.setSlotTagType(slot = 2, tagType = 0x04E8),
+        )
+    }
+
+    @Test
+    fun set_slot_enable_generic() {
+        // explicit senseType = 2 (example value, NOT the real SENSE_HF value)
+        assertArrayEquals(
+            hex("11 EF 03 EE 00 00 00 03 0C 01 02 01 FC"),
+            ChameleonCommands.setSlotEnable(slot = 1, senseType = 2, enable = true),
+        )
+    }
+
+    // --- Bounds ---
+
+    @Test
+    fun slot_out_of_range_throws() {
+        assertThrows(IllegalArgumentException::class.java) { ChameleonCommands.setActiveSlot(8) }
+        assertThrows(IllegalArgumentException::class.java) { ChameleonCommands.setActiveSlot(-1) }
+    }
+
+    // --- Frozen vectors using the resolved constants (chameleon_enum.py @ 6e2a902d) ---
+
+    @Test
+    fun set_slot_ntag215() {
+        // TAG_TYPE_NTAG215 = 1101 = 0x044D -> setSlotTagType(0, 0x044D)
+        assertArrayEquals(
+            hex("11 EF 03 EC 00 00 00 03 0E 00 04 4D AF"),
+            ChameleonCommands.setSlotNtag215(0),
+        )
+    }
+
+    @Test
+    fun set_hf_slot_enabled() {
+        // SENSE_HF = 2 -> setSlotEnable(0, 2, true)
+        assertArrayEquals(
+            hex("11 EF 03 EE 00 00 00 03 0C 00 02 01 FD"),
+            ChameleonCommands.setHfSlotEnabled(0),
+        )
+    }
+
+    @Test
+    fun write_emu_pages_vector() {
+        // OPCODE = MF0_NTAG_WRITE_EMU_PAGE_DATA = 4022 = 0x0FB6 ; layout page_start|count|data (verified)
+        assertArrayEquals(
+            hex("11 EF 0F B6 00 00 00 06 35 00 01 AA BB CC DD F1"),
+            ChameleonCommands.writeEmuPages(0, hex("AA BB CC DD")),
+        )
+    }
+
+    @Test
+    fun save_slot_config_vector() {
+        // OPCODE = SLOT_DATA_CONFIG_SAVE = 1009 = 0x03F1 ; no data
+        assertArrayEquals(
+            hex("11 EF 03 F1 00 00 00 00 0C 00"),
+            ChameleonCommands.saveSlotConfig(),
+        )
+    }
+
+    @Test
+    fun write_emu_pages_rejects_non_page_multiple() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ChameleonCommands.writeEmuPages(0, ByteArray(3)) // not a multiple of 4
+        }
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonFrameTest.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonFrameTest.kt
@@ -1,0 +1,77 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChameleonFrameTest {
+
+    // --- Frozen vectors (computed by hand, see docs/03) ---
+
+    @Test
+    fun encode_get_app_version_empty() {
+        // SOF EF | CMD 03E8 | STATUS 0000 | LEN 0000 | LRC2 15 | (no data) | LRC3 00
+        val expected = hex("11 EF 03 E8 00 00 00 00 15 00")
+        assertArrayEquals(expected, ChameleonFrame.encode(Command.GET_APP_VERSION))
+    }
+
+    @Test
+    fun encode_set_active_slot_zero() {
+        // CMD 03EB | STATUS 0000 | LEN 0001 | LRC2 11 | DATA 00 | LRC3 00
+        val expected = hex("11 EF 03 EB 00 00 00 01 11 00 00")
+        val frame = ChameleonFrame.encode(Command.SET_ACTIVE_SLOT, byteArrayOf(0x00))
+        assertArrayEquals(expected, frame)
+    }
+
+    @Test
+    fun decode_get_app_version_vector() {
+        val frame = ChameleonFrame.decode(hex("11 EF 03 E8 00 00 00 00 15 00")).getOrThrow()
+        assertEquals(1000, frame.cmd)
+        assertEquals(0, frame.status)
+        assertEquals(0, frame.data.size)
+    }
+
+    @Test
+    fun round_trip_with_payload() {
+        val data = ByteArray(64) { it.toByte() }
+        val encoded = ChameleonFrame.encode(0x1234, 0x0000, data)
+        val decoded = ChameleonFrame.decode(encoded).getOrThrow()
+        assertEquals(0x1234, decoded.cmd)
+        assertEquals(0x0000, decoded.status)
+        assertArrayEquals(data, decoded.data)
+    }
+
+    @Test
+    fun round_trip_max_data() {
+        val data = ByteArray(ChameleonFrame.MAX_DATA) { (it and 0xFF).toByte() }
+        val decoded = ChameleonFrame.decode(ChameleonFrame.encode(0x0001, 0, data)).getOrThrow()
+        assertArrayEquals(data, decoded.data)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun encode_rejects_oversized_data() {
+        ChameleonFrame.encode(0x0001, 0, ByteArray(ChameleonFrame.MAX_DATA + 1))
+    }
+
+    @Test
+    fun decode_rejects_bad_sof() {
+        assertTrue(ChameleonFrame.decode(hex("12 EF 03 E8 00 00 00 00 15 00")).isFailure)
+    }
+
+    @Test
+    fun decode_rejects_bad_lrc3() {
+        // dernier octet (LRC3) corrompu
+        assertTrue(ChameleonFrame.decode(hex("11 EF 03 E8 00 00 00 00 15 FF")).isFailure)
+    }
+
+    @Test
+    fun decode_rejects_trailing_bytes() {
+        assertTrue(ChameleonFrame.decode(hex("11 EF 03 E8 00 00 00 00 15 00 AA")).isFailure)
+    }
+
+    @Test
+    fun decode_incomplete_is_failure() {
+        assertTrue(ChameleonFrame.decode(hex("11 EF 03 E8 00")).isFailure)
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonResponsesTest.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonResponsesTest.kt
@@ -1,0 +1,52 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChameleonResponsesTest {
+
+    // --- AppVersion: fully verifiable comparison logic (used by the firmware gate) ---
+
+    @Test
+    fun app_version_ordering() {
+        assertTrue(AppVersion(2, 1) > AppVersion(2, 0))
+        assertTrue(AppVersion(3, 0) > AppVersion(2, 9))
+        assertEquals(0, AppVersion(2, 5).compareTo(AppVersion(2, 5)))
+        assertTrue(AppVersion(2, 0) < AppVersion(2, 1))
+    }
+
+    @Test
+    fun app_version_toString() {
+        assertEquals("2.7", AppVersion(2, 7).toString())
+    }
+
+    // --- parseAppVersion: confirmed layout (!BB = major, minor) ---
+
+    @Test
+    fun parse_app_version_confirmed() {
+        val frame = ChameleonFrame(Command.GET_APP_VERSION.code, 0, byteArrayOf(2, 3))
+        val v = ChameleonResponses.parseAppVersion(frame)
+        assertEquals(AppVersion(2, 3), v)
+    }
+
+    @Test
+    fun parse_app_version_rejects_short_payload() {
+        val frame = ChameleonFrame(Command.GET_APP_VERSION.code, 0, byteArrayOf(2))
+        assertThrows(IllegalArgumentException::class.java) { ChameleonResponses.parseAppVersion(frame) }
+    }
+
+    // --- isSuccess: amiibo-flow commands only succeed with STATUS_SUCCESS (0x68) ---
+
+    @Test
+    fun is_success_requires_status_success() {
+        // SUCCESS = 0x68 => success
+        assertTrue(ChameleonResponses.isSuccess(ChameleonFrame(Command.SET_ACTIVE_SLOT.code, 0x68, ByteArray(0))))
+        // 0x00 (HF_TAG_OK) is NOT a success for config commands => rejected (avoids masking errors)
+        assertFalse(ChameleonResponses.isSuccess(ChameleonFrame(Command.SET_ACTIVE_SLOT.code, 0x00, ByteArray(0))))
+        // PAR_ERR = 0x60 => failure
+        assertFalse(ChameleonResponses.isSuccess(ChameleonFrame(Command.SET_ACTIVE_SLOT.code, 0x60, ByteArray(0))))
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonUploaderTest.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/ChameleonUploaderTest.kt
@@ -1,0 +1,143 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChameleonUploaderTest {
+
+    private fun dump(size: Int) = ByteArray(size) { (it and 0xFF).toByte() }
+
+    @Test
+    fun upload_happy_path_sends_full_sequence() = runBlocking {
+        val transport = FakeChameleonTransport.allSuccess()
+        val uploader = ChameleonUploader(transport)
+        val data = dump(540)
+
+        val progress = mutableListOf<Pair<Int, Int>>()
+        uploader.uploadAmiibo(data, slot = 3, pagesPerBlock = 32) { w, t -> progress += w to t }
+
+        // 135 pages / 32 -> 5 write blocks ; full reference sequence
+        val cmds = transport.sent.map { it.cmd }
+        val expected = listOf(
+            Command.SET_ACTIVE_SLOT.code,
+            Command.SET_SLOT_TAG_TYPE.code,
+            Command.SET_SLOT_DATA_DEFAULT.code,
+            Command.MF0_NTAG_SET_VERSION_DATA.code,
+            Command.MF0_NTAG_SET_WRITE_MODE.code,
+            Command.MF0_NTAG_SET_UID_MAGIC_MODE.code,
+            Command.MF0_NTAG_SET_SIGNATURE_DATA.code,
+            Command.MF0_NTAG_WRITE_EMU_PAGE_DATA.code,
+            Command.MF0_NTAG_WRITE_EMU_PAGE_DATA.code,
+            Command.MF0_NTAG_WRITE_EMU_PAGE_DATA.code,
+            Command.MF0_NTAG_WRITE_EMU_PAGE_DATA.code,
+            Command.MF0_NTAG_WRITE_EMU_PAGE_DATA.code,
+            Command.HF14A_SET_ANTI_COLL_DATA.code,
+            Command.SET_SLOT_ENABLE.code,
+            Command.SLOT_DATA_CONFIG_SAVE.code,
+        )
+        assertEquals(expected, cmds)
+        assertEquals(0 to 5, progress.first())
+        assertEquals(5 to 5, progress.last())
+    }
+
+    @Test
+    fun upload_preserves_original_uid_in_first_write_block() = runBlocking {
+        val transport = FakeChameleonTransport.allSuccess()
+        val data = dump(540)
+        // UID = first 3 bytes of the dump (pages 0..2); must be sent as-is in the first block.
+        ChameleonUploader(transport).uploadAmiibo(data, slot = 0, pagesPerBlock = 32)
+
+        val firstWrite = transport.sent.first { it.cmd == Command.MF0_NTAG_WRITE_EMU_PAGE_DATA.code }
+        // payload = page_start(1) | count(1) | pages...
+        assertEquals(0, firstWrite.data[0].toInt())            // startPage 0
+        assertEquals(32, firstWrite.data[1].toInt())           // 32 pages
+        val pages = firstWrite.data.copyOfRange(2, firstWrite.data.size)
+        assertArrayEquals(data.copyOfRange(0, 32 * 4), pages)  // bytes identical to the dump (UID included)
+    }
+
+    @Test
+    fun upload_sets_anticollision_with_original_uid() = runBlocking {
+        val transport = FakeChameleonTransport.allSuccess()
+        val data = dump(540)
+        ChameleonUploader(transport).uploadAmiibo(data, slot = 0, pagesPerBlock = 32)
+        val antiColl = transport.sent.first { it.cmd == Command.HF14A_SET_ANTI_COLL_DATA.code }
+        // payload: uidLen(1) | uid(7) | atqa(2) | sak(1) | atsLen(1)
+        assertEquals(7, antiColl.data[0].toInt())
+        val uid = antiColl.data.copyOfRange(1, 8)
+        // UID = pages 0-1 minus BCC0 (byte index 3)
+        assertArrayEquals(
+            byteArrayOf(data[0], data[1], data[2], data[4], data[5], data[6], data[7]), uid,
+        )
+    }
+
+    @Test
+    fun upload_rejects_wrong_dump_size() {
+        val transport = FakeChameleonTransport.allSuccess()
+        assertThrows(IllegalArgumentException::class.java) {
+            // 100 bytes: neither 540, 532, nor > 540 -> rejected (aberrant size).
+            runBlocking { ChameleonUploader(transport).uploadAmiibo(ByteArray(100), slot = 0) }
+        }
+        // Nothing was sent: validation precedes any I/O.
+        assertTrue(transport.sent.isEmpty())
+    }
+
+    @Test
+    fun upload_accepts_532_byte_amiibo_variant() = runBlocking {
+        // 532-byte variant (without PWD/PACK): must be normalized to 540 and uploaded.
+        val transport = FakeChameleonTransport.allSuccess()
+        ChameleonUploader(transport).uploadAmiibo(dump(532), slot = 0, pagesPerBlock = 32)
+        val writes = transport.sent.filter { it.cmd == Command.MF0_NTAG_WRITE_EMU_PAGE_DATA.code }
+        // 540 normalized bytes -> 135 pages -> 5 blocks of 32.
+        assertEquals(5, writes.size)
+    }
+
+    @Test
+    fun upload_aborts_on_non_success_status() {
+        // Failure at SET_SLOT_TAG_TYPE: the following commands must not be sent.
+        val transport = FakeChameleonTransport { req ->
+            if (req.cmd == Command.SET_SLOT_TAG_TYPE.code) {
+                ChameleonFrame(req.cmd, 0x01, ByteArray(0)) // HF_TAG_NO
+            } else {
+                FakeChameleonTransport.ok(req)
+            }
+        }
+        assertThrows(ChameleonProtocolException::class.java) {
+            runBlocking { ChameleonUploader(transport).uploadAmiibo(dump(540), slot = 1) }
+        }
+        val cmds = transport.sent.map { it.cmd }
+        assertEquals(
+            listOf(Command.SET_ACTIVE_SLOT.code, Command.SET_SLOT_TAG_TYPE.code),
+            cmds,
+        )
+    }
+
+    @Test
+    fun upload_aborts_on_cmd_mismatch() {
+        val transport = FakeChameleonTransport { _ ->
+            ChameleonFrame(Command.GET_APP_VERSION.code, ChameleonProtocol.STATUS_SUCCESS, ByteArray(0))
+        }
+        assertThrows(ChameleonProtocolException::class.java) {
+            runBlocking { ChameleonUploader(transport).uploadAmiibo(dump(540), slot = 0) }
+        }
+    }
+
+    @Test
+    fun get_app_version_parses_response() = runBlocking {
+        val transport = FakeChameleonTransport.allSuccess(versionMajor = 2, versionMinor = 7)
+        val v = ChameleonUploader(transport).getAppVersion()
+        assertEquals(AppVersion(2, 7), v)
+        assertEquals(Command.GET_APP_VERSION.code, transport.sent.single().cmd)
+    }
+
+    @Test
+    fun upload_invalid_slot_rejected() {
+        val transport = FakeChameleonTransport.allSuccess()
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { ChameleonUploader(transport).uploadAmiibo(dump(540), slot = 8) }
+        }
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/FakeChameleonTransport.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/FakeChameleonTransport.kt
@@ -1,0 +1,35 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/**
+ * Simulated transport for JVM tests: decodes each request, records it, and returns the response
+ * produced by [responder]. Lets tests script success/error/unexpected-CMD without hardware.
+ */
+class FakeChameleonTransport(
+    private val responder: (ChameleonFrame) -> ChameleonFrame,
+) : ChameleonTransport {
+
+    /** Decoded request frames, in send order. */
+    val sent = mutableListOf<ChameleonFrame>()
+
+    override suspend fun send(request: ByteArray): ChameleonFrame {
+        val frame = ChameleonFrame.decode(request).getOrThrow()
+        sent += frame
+        return responder(frame)
+    }
+
+    companion object {
+        /** Generic success response (STATUS=0x68) echoing the request CMD. */
+        fun ok(request: ChameleonFrame, data: ByteArray = ByteArray(0)): ChameleonFrame =
+            ChameleonFrame(request.cmd, ChameleonProtocol.STATUS_SUCCESS, data)
+
+        /** Transport that always replies SUCCESS; special data for GET_APP_VERSION. */
+        fun allSuccess(versionMajor: Int = 2, versionMinor: Int = 1): FakeChameleonTransport =
+            FakeChameleonTransport { req ->
+                if (req.cmd == Command.GET_APP_VERSION.code) {
+                    ok(req, byteArrayOf(versionMajor.toByte(), versionMinor.toByte()))
+                } else {
+                    ok(req)
+                }
+            }
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/IncrementalFrameReaderTest.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/IncrementalFrameReaderTest.kt
@@ -1,0 +1,80 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IncrementalFrameReaderTest {
+
+    private val frameA = hex("11 EF 03 E8 00 00 00 00 15 00")        // GET_APP_VERSION, LEN=0
+    private val frameB = hex("11 EF 03 EB 00 00 00 01 11 00 00")     // SET_ACTIVE_SLOT slot 0, LEN=1
+
+    @Test
+    fun single_frame_in_one_append() {
+        val r = IncrementalFrameReader()
+        val out = r.append(frameA)
+        assertEquals(1, out.size)
+        assertEquals(1000, out[0].cmd)
+        assertEquals(0, r.pending)
+    }
+
+    @Test
+    fun two_frames_concatenated_in_one_append() {
+        val r = IncrementalFrameReader()
+        val out = r.append(frameA + frameB)
+        assertEquals(2, out.size)
+        assertEquals(1000, out[0].cmd)
+        assertEquals(1003, out[1].cmd)
+        assertEquals(0, r.pending)
+    }
+
+    @Test
+    fun frame_split_across_two_appends() {
+        val r = IncrementalFrameReader()
+        val first = r.append(frameA.copyOfRange(0, 5))  // half a frame
+        assertEquals(0, first.size)
+        assertEquals(5, r.pending)
+
+        val second = r.append(frameA.copyOfRange(5, frameA.size))
+        assertEquals(1, second.size)
+        assertEquals(1000, second[0].cmd)
+        assertEquals(0, r.pending)
+    }
+
+    @Test
+    fun leading_garbage_is_resynced() {
+        val r = IncrementalFrameReader()
+        val out = r.append(hex("00 AA FF") + frameA)
+        assertEquals(1, out.size)
+        assertEquals(1000, out[0].cmd)
+        assertEquals(0, r.pending)
+    }
+
+    @Test
+    fun garbage_between_two_frames() {
+        val r = IncrementalFrameReader()
+        val out = r.append(frameA + hex("DE AD") + frameB)
+        assertEquals(2, out.size)
+        assertEquals(1000, out[0].cmd)
+        assertEquals(1003, out[1].cmd)
+    }
+
+    @Test
+    fun byte_by_byte_feed() {
+        val r = IncrementalFrameReader()
+        var emitted = 0
+        for (b in frameB) {
+            emitted += r.append(byteArrayOf(b)).size
+        }
+        assertEquals(1, emitted)
+        assertEquals(0, r.pending)
+    }
+
+    @Test
+    fun reset_clears_pending() {
+        val r = IncrementalFrameReader()
+        r.append(frameA.copyOfRange(0, 5))
+        assertEquals(5, r.pending)
+        r.reset()
+        assertEquals(0, r.pending)
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/LrcTest.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/LrcTest.kt
@@ -1,0 +1,34 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/*
+ * JUnit4 (org.junit).
+ */
+class LrcTest {
+
+    @Test
+    fun lrc_of_sof_is_0xEF() {
+        // Core protocol property: LRC(0x11) == 0xEF.
+        assertEquals(0xEF, Lrc.compute(byteArrayOf(0x11)))
+    }
+
+    @Test
+    fun lrc_of_empty_is_zero() {
+        assertEquals(0x00, Lrc.compute(ByteArray(0)))
+    }
+
+    @Test
+    fun lrc_known_vector_cmd_status_len() {
+        // CMD=0x03E8 (GET_APP_VERSION=1000), STATUS=0, LEN=0  ->  expected LRC2 = 0x15
+        val bytes = hex("03 E8 00 00 00 00")
+        assertEquals(0x15, Lrc.compute(bytes))
+    }
+
+    @Test
+    fun lrc_is_complement_to_256() {
+        // sum = 0x01+0x02+0x03 = 6  ->  (256-6)=250=0xFA
+        assertEquals(0xFA, Lrc.compute(byteArrayOf(0x01, 0x02, 0x03)))
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/PageChunkerTest.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/PageChunkerTest.kt
@@ -1,0 +1,71 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class PageChunkerTest {
+
+    private fun dump(size: Int) = ByteArray(size) { (it and 0xFF).toByte() }
+
+    @Test
+    fun chunks_ntag215_540_into_blocks_of_32_pages() {
+        val blocks = PageChunker.chunkByPages(dump(540), pagesPerBlock = 32)
+        // 135 pages -> 32,32,32,32,7
+        assertEquals(5, blocks.size)
+        assertEquals(listOf(0, 32, 64, 96, 128), blocks.map { it.startPage })
+        assertEquals(listOf(32, 32, 32, 32, 7), blocks.map { it.pageCount })
+        assertEquals(7 * 4, blocks.last().data.size)
+    }
+
+    @Test
+    fun blocks_reconstruct_original_dump() {
+        val original = dump(540)
+        val rebuilt = PageChunker.chunkByPages(original, pagesPerBlock = 16)
+            .fold(ByteArray(0)) { acc, b -> acc + b.data }
+        assertArrayEquals(original, rebuilt)
+    }
+
+    @Test
+    fun single_block_when_block_larger_than_dump() {
+        val blocks = PageChunker.chunkByPages(dump(540), pagesPerBlock = 1000)
+        assertEquals(1, blocks.size)
+        assertEquals(0, blocks[0].startPage)
+        assertEquals(135, blocks[0].pageCount)
+    }
+
+    @Test
+    fun rejects_non_page_multiple() {
+        assertThrows(IllegalArgumentException::class.java) {
+            PageChunker.chunkByPages(dump(541), pagesPerBlock = 32)
+        }
+    }
+
+    @Test
+    fun require_ntag215_accepts_540_rejects_others() {
+        PageChunker.requireNtag215(dump(540)) // does not throw
+        assertThrows(IllegalArgumentException::class.java) { PageChunker.requireNtag215(dump(532)) }
+        assertThrows(IllegalArgumentException::class.java) { PageChunker.requireNtag215(dump(572)) }
+    }
+
+    @Test
+    fun normalize_handles_540_532_and_larger() {
+        // 540: unchanged
+        assertEquals(540, PageChunker.normalizeToNtag215(dump(540)).size)
+        // 532: padded to 540, first 532 bytes preserved, last 8 zeroed
+        val padded = PageChunker.normalizeToNtag215(dump(532))
+        assertEquals(540, padded.size)
+        assertArrayEquals(dump(532), padded.copyOfRange(0, 532))
+        assertArrayEquals(ByteArray(8), padded.copyOfRange(532, 540))
+        // 572: truncated to the first 540
+        val truncated = PageChunker.normalizeToNtag215(dump(572))
+        assertEquals(540, truncated.size)
+        assertArrayEquals(dump(572).copyOfRange(0, 540), truncated)
+    }
+
+    @Test
+    fun normalize_rejects_aberrant_size() {
+        assertThrows(IllegalArgumentException::class.java) { PageChunker.normalizeToNtag215(dump(100)) }
+    }
+}

--- a/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/TestHex.kt
+++ b/app/src/test/java/com/hiddenramblings/tagmo/bluetooth/chameleon/protocol/TestHex.kt
@@ -1,0 +1,12 @@
+package com.hiddenramblings.tagmo.bluetooth.chameleon.protocol
+
+/** Hex helpers for tests (spaces ignored). */
+internal fun hex(s: String): ByteArray {
+    val clean = s.replace(" ", "").replace("\n", "")
+    require(clean.length % 2 == 0) { "longueur hex impaire" }
+    return ByteArray(clean.length / 2) {
+        ((Character.digit(clean[it * 2], 16) shl 4) + Character.digit(clean[it * 2 + 1], 16)).toByte()
+    }
+}
+
+internal fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/docs/chameleon-usage.md
+++ b/docs/chameleon-usage.md
@@ -1,0 +1,33 @@
+# Utiliser le ChameleonUltra avec TagMo
+
+Pousse un amiibo (NTAG215) depuis TagMo vers un slot d'émulation du ChameleonUltra, en BLE.
+
+## Prérequis
+- Un **ChameleonUltra** (firmware ≥ v2.1 testé), chargé et réveillé (il s'endort : appuie sur le bouton).
+- Téléphone Android avec Bluetooth activé et les permissions BLE accordées à TagMo.
+- (Pour le mode « random serial » uniquement) tes **clés amiibo chargées dans TagMo**.
+
+## Pousser un amiibo
+1. Ouvre l'écran **Bluetooth / GATT** de TagMo, lance le scan (loupe).
+2. Sélectionne **« ChameleonUltra »** dans la liste (laisse le type sur *Autodetect*) → connecte.
+   - Une fois connecté, l'en-tête affiche `ChameleonUltra (vX.Y)`.
+3. **« Upload binary to GATT device »** → choisis l'amiibo → choisis le **slot (1–8)**.
+4. La progression s'affiche bloc par bloc ; un message confirme l'envoi.
+5. Le slot émule l'amiibo : un lecteur NFC tiers (Switch, etc.) le reconnaît.
+
+### Raccourci depuis le navigateur d'amiibos
+Sur un amiibo : **Export to GATT** → sélectionne le ChameleonUltra → le choix du slot s'ouvre
+directement (pas besoin de re-choisir l'amiibo).
+
+## Modes
+- **Clone à l'identique** (défaut) : l'UID d'origine est conservé ; le dump est poussé tel quel.
+- **Clone with random serial** (interrupteur) : TagMo génère un amiibo à **UID aléatoire**, re-signé
+  avec **tes** clés, avant l'envoi. Nécessite les clés amiibo chargées dans TagMo.
+
+## Dépannage
+- *Il n'apparaît pas au scan* : réveille le Chameleon (bouton) et relance le scan.
+- *« Timed out »* à la connexion : réveille-le et réessaie ; rapproche le téléphone.
+- *« Charge tes clés amiibo… »* : le mode random serial exige les clés amiibo dans TagMo.
+- *Taille de dump* : les variantes 532/540/572 octets sont normalisées automatiquement à 540.
+
+> Périmètre & licences : voir `docs/09-licensing-scope.md`. Dumps personnels uniquement.


### PR DESCRIPTION
# Add ChameleonUltra as a BLE device (push amiibo dumps to emulator slots)

## Summary

Adds the **ChameleonUltra** as a new BLE device alongside the existing ones (Flask, Puck.js,
Pixl.js, AmiiboLink, AmiLoop…). It lets you push an NTAG215 amiibo dump from TagMo straight into
a ChameleonUltra emulator slot over BLE, replicating the CLI flow
`hw slot change → hw slot type (NTAG215) → hf mfu eload → hw slot store`.

Tested on hardware (ChameleonUltra firmware **v2.1**): a **Nintendo Switch** accepts both cloned and
random-serial amiibo written this way.

## What's included

- **Protocol codec** (`bluetooth/chameleon/protocol/`, pure Kotlin, JVM-tested): frame encode/decode
  with LRC, incremental frame reassembly, typed commands, and an upload orchestrator. **52 unit tests.**
- **BLE transport** (`ChameleonBleTransport`): dedicated GATT link over the NUS service (same UUIDs
  the app already scans), MTU negotiation, serialized GATT ops, chunking, response correlation by CMD.
- **Full emulation setup** (matches the chameleon-ultra-amiibo reference so a Switch validates the tag):
  slot type + data default, GET_VERSION, READ_SIG signature, the 135 pages, and the anti-collision UID
  so the broadcast UID matches the amiibo's UID-bound signature.
- **Native UI integration**: the Chameleon shows up in the existing Bluetooth picker (detected by name
  over the NUS scan), connects, shows firmware version, and exposes a clean slot picker (1–8) for upload.
  "Export to GATT" from the browser goes straight to the slot picker.
- Optional **random serial**: reuses TagMo's existing generation (`withRandomSerials` + `KeyManager`)
  with the user's own keys — no new crypto, no bundled keys. The NTAG215 password (PWD/PACK) is derived
  from the UID with TagMo's existing public algorithm, in the amiibo-aware UI layer.

## Scope & safety

- Personal dumps only. The transport/protocol layer is **generic NTAG215** (no amiibo-specific logic).
- **No amiibo crypto is implemented here and no keys are bundled.** The "clone as-is" path preserves the
  original UID and pushes the existing `.bin` untouched; the optional random-serial path delegates entirely
  to TagMo's own KeyManager using keys the user loaded. See `docs/09-licensing-scope.md`.

## Provenance / licensing

- Opcodes, enum values, statuses, signatures and BLE UUIDs are **extracted from pinned upstream sources**
  with `file:line@SHA` provenance (`constants/chameleon-extracted.md`, `docs/08-sources.md`):
  `RfidResearchGroup/ChameleonUltra` (GPLv3) and `taichunmin/chameleon-ultra.js` (MIT).
- New code is an original Kotlin implementation (clean-room from the protocol spec), GPLv3-compatible.

## How to test

1. Wake the ChameleonUltra, open the Bluetooth/GATT screen, scan → select **ChameleonUltra**.
2. Confirm it connects and shows the firmware version.
3. "Upload binary to GATT device" (or "Export to GATT" from an amiibo) → pick a slot → upload.
4. Read the slot with a third-party reader: the amiibo is recognized; UID matches the source
   (or is a valid new UID when "Clone with random serial" is on).

## Notes for reviewers

- New code is isolated under `bluetooth/chameleon/`; integration touches `Nordic.kt` (one enum entry)
  and `GattSlotFragment.kt`/`BrowserActivity.kt` (guarded `CHAMELEON_ULTRA` branches), without altering
  existing device flows.
- BLE timing constants (MTU target, inter-chunk delay, timeouts) are conservative and centralized in
  `ChameleonBleTransport` for easy tuning.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
